### PR TITLE
feat: 알림 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.6'
+    id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     // Web
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
@@ -36,8 +36,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     // Test
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'com.h2database:h2'
     testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationInfo.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationInfo.java
@@ -40,4 +40,28 @@ public class NotificationInfo {
             );
         }
     }
+
+    public record ListItem(
+            Long notificationId,
+            NotificationType notificationType,
+            NotificationChannel channel,
+            NotificationStatus status,
+            boolean isRead,
+            String message,
+            LocalDateTime sentAt,
+            LocalDateTime createdAt
+    ) {
+        public static ListItem from(Notification notification, String message) {
+            return new ListItem(
+                    notification.getId(),
+                    notification.getNotificationType(),
+                    notification.getChannel(),
+                    notification.getStatus(),
+                    notification.getStatus() == NotificationStatus.READ,
+                    message,
+                    notification.getSentAt(),
+                    notification.getCreatedAt()
+            );
+        }
+    }
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationInfo.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationInfo.java
@@ -1,0 +1,43 @@
+package com.becnotificationsystem.application.notification;
+
+import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
+import com.becnotificationsystem.domain.notification.NotificationType;
+
+import java.time.LocalDateTime;
+
+public class NotificationInfo {
+
+    public record Detail(
+            Long notificationId,
+            NotificationStatus status,
+            Long receiverId,
+            NotificationType notificationType,
+            NotificationChannel channel,
+            Long referenceId,
+            String referenceType,
+            int retryCount,
+            String failureReason,
+            LocalDateTime scheduledAt,
+            LocalDateTime sentAt,
+            LocalDateTime createdAt
+    ) {
+        public static Detail from(Notification notification) {
+            return new Detail(
+                    notification.getId(),
+                    notification.getStatus(),
+                    notification.getReceiverId(),
+                    notification.getNotificationType(),
+                    notification.getChannel(),
+                    notification.getReferenceId(),
+                    notification.getReferenceType(),
+                    notification.getRetryCount(),
+                    notification.getFailureReason(),
+                    notification.getScheduledAt(),
+                    notification.getSentAt(),
+                    notification.getCreatedAt()
+            );
+        }
+    }
+}

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
@@ -1,12 +1,20 @@
 package com.becnotificationsystem.application.notification;
 
 import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface NotificationRepository {
 
     Notification save(Notification notification);
 
     Optional<Notification> findByIdAndDeletedFalse(Long id);
+
+    Page<Notification> findByReceiverIdAndStatusAndDeletedFalse(
+            Long receiverId, NotificationStatus status, Pageable pageable);
+
+    Page<Notification> findByReceiverIdAndDeletedFalse(Long receiverId, Pageable pageable);
 
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
@@ -1,0 +1,9 @@
+package com.becnotificationsystem.application.notification;
+
+import com.becnotificationsystem.domain.notification.Notification;
+
+public interface NotificationRepository {
+
+    Notification save(Notification notification);
+
+}

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
@@ -1,9 +1,12 @@
 package com.becnotificationsystem.application.notification;
 
 import com.becnotificationsystem.domain.notification.Notification;
+import java.util.Optional;
 
 public interface NotificationRepository {
 
     Notification save(Notification notification);
+
+    Optional<Notification> findByIdAndDeletedFalse(Long id);
 
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
@@ -1,6 +1,8 @@
 package com.becnotificationsystem.application.notification;
 
 import com.becnotificationsystem.domain.notification.*;
+import com.becnotificationsystem.global.exception.BusinessException;
+import com.becnotificationsystem.global.exception.ErrorCode;
 import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,6 +36,12 @@ public class NotificationService {
         );
 
         return NotificationInfo.Detail.from(notificationRepository.save(notification));
+    }
+
+    public NotificationInfo.Detail findById(Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndDeletedFalse(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        return NotificationInfo.Detail.from(notification);
     }
 
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
@@ -1,0 +1,39 @@
+package com.becnotificationsystem.application.notification;
+
+import com.becnotificationsystem.domain.notification.*;
+import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public NotificationInfo.Detail register(NotificationCreateRequest request) {
+        String idempotencyKey = Notification.generateIdempotencyKey(
+                request.receiverId(),
+                request.notificationType(),
+                request.referenceId(),
+                request.referenceType(),
+                request.channel()
+        );
+
+        Notification notification = Notification.of(
+                request.receiverId(),
+                request.notificationType(),
+                request.channel(),
+                request.referenceId(),
+                request.referenceType(),
+                idempotencyKey,
+                request.scheduledAt()
+        );
+
+        return NotificationInfo.Detail.from(notificationRepository.save(notification));
+    }
+
+}

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
@@ -1,10 +1,14 @@
 package com.becnotificationsystem.application.notification;
 
+import com.becnotificationsystem.application.notification.NotificationInfo.ListItem;
 import com.becnotificationsystem.domain.notification.*;
+import com.becnotificationsystem.global.common.response.PageResponse;
 import com.becnotificationsystem.global.exception.BusinessException;
 import com.becnotificationsystem.global.exception.ErrorCode;
 import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +46,21 @@ public class NotificationService {
         Notification notification = notificationRepository.findByIdAndDeletedFalse(notificationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
         return NotificationInfo.Detail.from(notification);
+    }
+
+    public PageResponse<ListItem> findByReceiverId(Long receiverId, Boolean readFilter, Pageable pageable) {
+        Page<Notification> notificationPage;
+        if (readFilter == null) {
+            notificationPage = notificationRepository.findByReceiverIdAndDeletedFalse(receiverId, pageable);
+        } else if (readFilter) {
+            notificationPage = notificationRepository.findByReceiverIdAndStatusAndDeletedFalse(
+                    receiverId, NotificationStatus.READ, pageable);
+        } else {
+            notificationPage = notificationRepository.findByReceiverIdAndStatusAndDeletedFalse(
+                    receiverId, NotificationStatus.SENT, pageable);
+        }
+
+        return PageResponse.from(notificationPage.map(n -> NotificationInfo.ListItem.from(n, null)));
     }
 
 }

--- a/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
@@ -2,6 +2,9 @@ package com.becnotificationsystem.domain.notification;
 
 import com.becnotificationsystem.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -95,5 +98,22 @@ public class Notification extends BaseEntity {
                 .scheduledAt(scheduledAt)
                 .deleted(false)
                 .build();
+    }
+
+    public static String generateIdempotencyKey(Long receiverId, NotificationType notificationType,
+                                                Long referenceId, String referenceType,
+                                                NotificationChannel channel) {
+        String raw = receiverId + ":" + notificationType.name() + ":" + referenceId + ":" + referenceType + ":" + channel.name();
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(raw.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
     }
 }

--- a/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
@@ -1,0 +1,99 @@
+package com.becnotificationsystem.domain.notification;
+
+import com.becnotificationsystem.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@Entity
+@Table(
+        name = "notification",
+        uniqueConstraints = @UniqueConstraint(name = "uk_idempotency_key", columnNames = "idempotency_key")
+)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long receiverId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private NotificationType notificationType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NotificationChannel channel;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NotificationStatus status;
+
+    @Column(nullable = false)
+    private Long referenceId;
+
+    @Column(nullable = false, length = 50)
+    private String referenceType;
+
+    @Column(nullable = false, length = 255)
+    private String idempotencyKey;
+
+    @Column(nullable = false)
+    private int retryCount;
+
+    @Column(nullable = false)
+    private int maxRetryCount;
+
+    @Column(columnDefinition = "TEXT")
+    private String failureReason;
+
+    private LocalDateTime scheduledAt;
+    private LocalDateTime sentAt;
+    private LocalDateTime readAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted;
+
+    @Builder
+    private Notification(Long receiverId, NotificationType notificationType, NotificationChannel channel,
+                         NotificationStatus status, Long referenceId, String referenceType,
+                         String idempotencyKey, int retryCount, int maxRetryCount,
+                         LocalDateTime scheduledAt, boolean deleted) {
+        this.receiverId = receiverId;
+        this.notificationType = notificationType;
+        this.channel = channel;
+        this.status = status;
+        this.referenceId = referenceId;
+        this.referenceType = referenceType;
+        this.idempotencyKey = idempotencyKey;
+        this.retryCount = retryCount;
+        this.maxRetryCount = maxRetryCount;
+        this.scheduledAt = scheduledAt;
+        this.deleted = deleted;
+    }
+
+    public static Notification of(Long receiverId, NotificationType notificationType, NotificationChannel channel,
+                                   Long referenceId, String referenceType, String idempotencyKey,
+                                   LocalDateTime scheduledAt) {
+        return Notification.builder()
+                .receiverId(receiverId)
+                .notificationType(notificationType)
+                .channel(channel)
+                .status(NotificationStatus.PENDING)
+                .referenceId(referenceId)
+                .referenceType(referenceType)
+                .idempotencyKey(idempotencyKey)
+                .retryCount(0)
+                .maxRetryCount(3)
+                .scheduledAt(scheduledAt)
+                .deleted(false)
+                .build();
+    }
+}

--- a/src/main/java/com/becnotificationsystem/domain/notification/NotificationChannel.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/NotificationChannel.java
@@ -1,0 +1,6 @@
+package com.becnotificationsystem.domain.notification;
+
+public enum NotificationChannel {
+    EMAIL,
+    IN_APP
+}

--- a/src/main/java/com/becnotificationsystem/domain/notification/NotificationStatus.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/NotificationStatus.java
@@ -1,0 +1,10 @@
+package com.becnotificationsystem.domain.notification;
+
+public enum NotificationStatus {
+    PENDING,
+    PROCESSING,
+    SENT,
+    FAILED,
+    DEAD_LETTER,
+    READ
+}

--- a/src/main/java/com/becnotificationsystem/domain/notification/NotificationType.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/NotificationType.java
@@ -1,0 +1,8 @@
+package com.becnotificationsystem.domain.notification;
+
+public enum NotificationType {
+    ENROLLMENT_COMPLETE,
+    PAYMENT_CONFIRMED,
+    LECTURE_REMINDER,
+    CANCELLATION
+}

--- a/src/main/java/com/becnotificationsystem/global/common/response/CommonApiResponse.java
+++ b/src/main/java/com/becnotificationsystem/global/common/response/CommonApiResponse.java
@@ -26,6 +26,14 @@ public class CommonApiResponse<T> {
                 .build();
     }
 
+    public static <T> CommonApiResponse<T> success(T data, String message) {
+        return CommonApiResponse.<T>builder()
+                .code(ResponseCode.SUCCESS.getCode())
+                .message(message)
+                .data(data)
+                .build();
+    }
+
     public static <T> CommonApiResponse<T> fail(ErrorCode errorCode) {
         return CommonApiResponse.<T>builder()
                 .code(errorCode.getCode())

--- a/src/main/java/com/becnotificationsystem/global/common/response/PageResponse.java
+++ b/src/main/java/com/becnotificationsystem/global/common/response/PageResponse.java
@@ -1,0 +1,25 @@
+package com.becnotificationsystem.global.common.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean isLast
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/com/becnotificationsystem/global/exception/ErrorCode.java
+++ b/src/main/java/com/becnotificationsystem/global/exception/ErrorCode.java
@@ -8,9 +8,10 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
     NOTIFICATION_NOT_FOUND(404, "NOTIFICATION_NOT_FOUND", "알림을 찾을 수 없습니다."),
-    DUPLICATE_NOTIFICATION(409, "DUPLICATE_NOTIFICATION", "이미 처리된 알림 요청입니다."),
-    INVALID_CHANNEL(400, "INVALID_CHANNEL", "지원하지 않는 발송 채널입니다."),
-    INVALID_NOTIFICATION_TYPE(400, "INVALID_NOTIFICATION_TYPE", "지원하지 않는 알림 타입입니다.");
+    NOTIFICATION_DUPLICATE(409, "NOTIFICATION_DUPLICATE", "동일한 이벤트에 대한 알림이 이미 존재합니다."),
+    NOTIFICATION_CHANNEL_NOT_SUPPORTED(400, "NOTIFICATION_CHANNEL_NOT_SUPPORTED", "해당 채널에서 지원하지 않는 동작입니다."),
+    NOTIFICATION_RETRY_NOT_ALLOWED(400, "NOTIFICATION_RETRY_NOT_ALLOWED", "재시도 불가 상태의 알림입니다."),
+    NOTIFICATION_ACCESS_DENIED(403, "NOTIFICATION_ACCESS_DENIED", "수신자 본인만 처리할 수 있습니다.");
 
     private final int status;
     private final String code;

--- a/src/main/java/com/becnotificationsystem/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/becnotificationsystem/global/exception/GlobalExceptionHandler.java
@@ -34,6 +34,14 @@ public class GlobalExceptionHandler {
                 .body(CommonApiResponse.fail("INVALID_INPUT", message));
     }
 
+    @ExceptionHandler(org.springframework.web.bind.ServletRequestBindingException.class)
+    public ResponseEntity<CommonApiResponse<Void>> handleBindingException(org.springframework.web.bind.ServletRequestBindingException e) {
+        log.warn("BindingException: {}", e.getMessage());
+        return ResponseEntity
+                .badRequest()
+                .body(CommonApiResponse.fail("INVALID_INPUT", e.getMessage()));
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<CommonApiResponse<Void>> handleException(Exception e) {
         log.error("Unhandled exception", e);

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
@@ -1,11 +1,19 @@
 package com.becnotificationsystem.infrastructure.notification;
 
 import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
 
     Optional<Notification> findByIdAndDeletedFalse(Long id);
+
+    Page<Notification> findByReceiverIdAndStatusAndDeletedFalse(
+            Long receiverId, NotificationStatus status, Pageable pageable);
+
+    Page<Notification> findByReceiverIdAndDeletedFalse(Long receiverId, Pageable pageable);
 
 }

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
@@ -1,7 +1,11 @@
 package com.becnotificationsystem.infrastructure.notification;
 
 import com.becnotificationsystem.domain.notification.Notification;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
+
+    Optional<Notification> findByIdAndDeletedFalse(Long id);
+
 }

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
@@ -1,0 +1,7 @@
+package com.becnotificationsystem.infrastructure.notification;
+
+import com.becnotificationsystem.domain.notification.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.becnotificationsystem.infrastructure.notification;
+
+import com.becnotificationsystem.application.notification.NotificationRepository;
+import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.global.exception.BusinessException;
+import com.becnotificationsystem.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepository {
+
+    private final NotificationJpaRepository notificationJpaRepository;
+
+    @Override
+    public Notification save(Notification notification) {
+        try {
+            return notificationJpaRepository.saveAndFlush(notification);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_DUPLICATE);
+        }
+    }
+}

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
@@ -2,11 +2,14 @@ package com.becnotificationsystem.infrastructure.notification;
 
 import com.becnotificationsystem.application.notification.NotificationRepository;
 import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
 import com.becnotificationsystem.global.exception.BusinessException;
 import com.becnotificationsystem.global.exception.ErrorCode;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -27,5 +30,16 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     @Override
     public Optional<Notification> findByIdAndDeletedFalse(Long id) {
         return notificationJpaRepository.findByIdAndDeletedFalse(id);
+    }
+
+    @Override
+    public Page<Notification> findByReceiverIdAndStatusAndDeletedFalse(
+            Long receiverId, NotificationStatus status, Pageable pageable) {
+        return notificationJpaRepository.findByReceiverIdAndStatusAndDeletedFalse(receiverId, status, pageable);
+    }
+
+    @Override
+    public Page<Notification> findByReceiverIdAndDeletedFalse(Long receiverId, Pageable pageable) {
+        return notificationJpaRepository.findByReceiverIdAndDeletedFalse(receiverId, pageable);
     }
 }

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.becnotificationsystem.application.notification.NotificationRepository
 import com.becnotificationsystem.domain.notification.Notification;
 import com.becnotificationsystem.global.exception.BusinessException;
 import com.becnotificationsystem.global.exception.ErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
@@ -21,5 +22,10 @@ public class NotificationRepositoryImpl implements NotificationRepository {
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.NOTIFICATION_DUPLICATE);
         }
+    }
+
+    @Override
+    public Optional<Notification> findByIdAndDeletedFalse(Long id) {
+        return notificationJpaRepository.findByIdAndDeletedFalse(id);
     }
 }

--- a/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
@@ -1,10 +1,15 @@
 package com.becnotificationsystem.interfaces.api.notification;
 
 import com.becnotificationsystem.application.notification.NotificationInfo;
+import com.becnotificationsystem.application.notification.NotificationInfo.ListItem;
 import com.becnotificationsystem.application.notification.NotificationService;
 import com.becnotificationsystem.global.common.response.CommonApiResponse;
+import com.becnotificationsystem.global.common.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,5 +31,13 @@ public class NotificationController {
     public CommonApiResponse<NotificationInfo.Detail> getStatus(
             @PathVariable Long notificationId) {
         return CommonApiResponse.success(notificationService.findById(notificationId), "조회 성공");
+    }
+
+    @GetMapping
+    public CommonApiResponse<PageResponse<ListItem>> getList(
+            @RequestHeader("X-User-Id") Long userId,
+            @RequestParam(required = false) Boolean readFilter,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return CommonApiResponse.success(notificationService.findByReceiverId(userId, readFilter, pageable), "조회 성공");
     }
 }

--- a/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
@@ -1,0 +1,24 @@
+package com.becnotificationsystem.interfaces.api.notification;
+
+import com.becnotificationsystem.application.notification.NotificationInfo;
+import com.becnotificationsystem.application.notification.NotificationService;
+import com.becnotificationsystem.global.common.response.CommonApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public CommonApiResponse<NotificationInfo.Detail> register(
+            @Valid @RequestBody NotificationCreateRequest request) {
+        return CommonApiResponse.success(notificationService.register(request), "알림 발송 요청이 접수되었습니다.");
+    }
+}

--- a/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
@@ -21,4 +21,10 @@ public class NotificationController {
             @Valid @RequestBody NotificationCreateRequest request) {
         return CommonApiResponse.success(notificationService.register(request), "알림 발송 요청이 접수되었습니다.");
     }
+
+    @GetMapping("/{notificationId}")
+    public CommonApiResponse<NotificationInfo.Detail> getStatus(
+            @PathVariable Long notificationId) {
+        return CommonApiResponse.success(notificationService.findById(notificationId), "조회 성공");
+    }
 }

--- a/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationCreateRequest.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationCreateRequest.java
@@ -1,0 +1,27 @@
+package com.becnotificationsystem.interfaces.api.notification;
+
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+import com.becnotificationsystem.domain.notification.NotificationType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record NotificationCreateRequest(
+        @NotNull(message = "수신자 ID는 필수입니다.")
+        Long receiverId,
+
+        @NotNull(message = "알림 타입은 필수입니다.")
+        NotificationType notificationType,
+
+        @NotNull(message = "발송 채널은 필수입니다.")
+        NotificationChannel channel,
+
+        @NotNull(message = "참조 ID는 필수입니다.")
+        Long referenceId,
+
+        @NotBlank(message = "참조 타입은 필수입니다.")
+        String referenceType,
+
+        LocalDateTime scheduledAt
+) {}

--- a/src/test/java/com/becnotificationsystem/application/notification/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/becnotificationsystem/application/notification/NotificationServiceIntegrationTest.java
@@ -1,0 +1,284 @@
+package com.becnotificationsystem.application.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
+import com.becnotificationsystem.domain.notification.NotificationType;
+import com.becnotificationsystem.global.common.response.PageResponse;
+import com.becnotificationsystem.global.exception.BusinessException;
+import com.becnotificationsystem.global.exception.ErrorCode;
+import com.becnotificationsystem.infrastructure.notification.NotificationJpaRepository;
+import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NotificationServiceIntegrationTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @MockitoSpyBean
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private NotificationJpaRepository notificationJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        notificationJpaRepository.deleteAll();
+    }
+
+    @DisplayName("알림을 등록할 때,")
+    @Nested
+    class Register {
+
+        @DisplayName("유효한 요청이 주어지면 PENDING 상태의 알림이 저장되고 Detail이 반환된다.")
+        @Test
+        void savesNotification_whenRequestIsValid() {
+            // arrange
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    1L,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.EMAIL,
+                    100L,
+                    "ORDER",
+                    null
+            );
+
+            // act
+            NotificationInfo.Detail result = notificationService.register(request);
+
+            // assert
+            assertAll(
+                    () -> assertThat(result.notificationId()).isNotNull(),
+                    () -> assertThat(result.status()).isEqualTo(NotificationStatus.PENDING),
+                    () -> assertThat(result.receiverId()).isEqualTo(1L),
+                    () -> assertThat(result.notificationType()).isEqualTo(NotificationType.ENROLLMENT_COMPLETE),
+                    () -> assertThat(result.channel()).isEqualTo(NotificationChannel.EMAIL),
+                    () -> assertThat(result.referenceId()).isEqualTo(100L),
+                    () -> assertThat(result.referenceType()).isEqualTo("ORDER"),
+                    () -> assertThat(result.retryCount()).isEqualTo(0),
+                    () -> assertThat(result.createdAt()).isNotNull()
+            );
+
+            // verify
+            verify(notificationRepository, times(1)).save(any(Notification.class));
+        }
+
+        @DisplayName("동일한 요청이 중복으로 들어오면 NOTIFICATION_DUPLICATE 예외가 발생한다.")
+        @Test
+        void throwsException_whenDuplicateRequestGiven() {
+            // arrange
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    1L,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.EMAIL,
+                    100L,
+                    "ORDER",
+                    null
+            );
+            notificationService.register(request);
+
+            // act & assert
+            BusinessException exception = assertThrows(BusinessException.class, () ->
+                    notificationService.register(request)
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_DUPLICATE);
+        }
+    }
+
+    @DisplayName("알림을 ID로 조회할 때,")
+    @Nested
+    class FindById {
+
+        @DisplayName("존재하는 알림 ID로 조회하면 알림 상세 정보가 반환된다.")
+        @Test
+        void returnsDetail_whenNotificationExists() {
+            // arrange
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    1L,
+                    NotificationType.PAYMENT_CONFIRMED,
+                    NotificationChannel.IN_APP,
+                    200L,
+                    "PAYMENT",
+                    null
+            );
+            NotificationInfo.Detail saved = notificationService.register(request);
+
+            // act
+            NotificationInfo.Detail result = notificationService.findById(saved.notificationId());
+
+            // assert
+            assertAll(
+                    () -> assertThat(result.notificationId()).isEqualTo(saved.notificationId()),
+                    () -> assertThat(result.receiverId()).isEqualTo(1L),
+                    () -> assertThat(result.notificationType()).isEqualTo(NotificationType.PAYMENT_CONFIRMED),
+                    () -> assertThat(result.channel()).isEqualTo(NotificationChannel.IN_APP),
+                    () -> assertThat(result.status()).isEqualTo(NotificationStatus.PENDING)
+            );
+        }
+
+        @DisplayName("존재하지 않는 알림 ID로 조회하면 NOTIFICATION_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void throwsException_whenNotificationDoesNotExist() {
+            // arrange
+            Long nonExistentId = 999L;
+
+            // act & assert
+            BusinessException exception = assertThrows(BusinessException.class, () ->
+                    notificationService.findById(nonExistentId)
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+
+        @DisplayName("soft-delete된 알림 ID로 조회하면 NOTIFICATION_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void throwsException_whenNotificationIsSoftDeleted() {
+            // arrange
+            Notification deleted = Notification.builder()
+                    .receiverId(1L)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.PENDING)
+                    .referenceId(1L)
+                    .referenceType("ORDER")
+                    .idempotencyKey("deleted-key")
+                    .retryCount(0)
+                    .maxRetryCount(3)
+                    .deleted(true)
+                    .build();
+            Notification saved = notificationJpaRepository.save(deleted);
+
+            // act & assert
+            BusinessException exception = assertThrows(BusinessException.class, () ->
+                    notificationService.findById(saved.getId())
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+    }
+
+    @DisplayName("수신자 ID로 알림 목록을 조회할 때,")
+    @Nested
+    class FindByReceiverId {
+
+        @DisplayName("readFilter가 null이면 수신자의 삭제되지 않은 모든 알림 목록을 반환한다.")
+        @Test
+        void returnsAllNotifications_whenReadFilterIsNull() {
+            // arrange
+            Long receiverId = 1L;
+            notificationService.register(new NotificationCreateRequest(receiverId, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL, 1L, "ORDER", null));
+            notificationService.register(new NotificationCreateRequest(receiverId, NotificationType.PAYMENT_CONFIRMED, NotificationChannel.IN_APP, 2L, "PAYMENT", null));
+
+            // act
+            PageResponse<NotificationInfo.ListItem> result = notificationService.findByReceiverId(receiverId, null, PageRequest.of(0, 20));
+
+            // assert
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.totalElements()).isEqualTo(2);
+        }
+
+        @DisplayName("readFilter가 false이면 SENT 상태의 알림만 반환한다.")
+        @Test
+        void returnsSentNotificationsOnly_whenReadFilterIsFalse() {
+            // arrange
+            Long receiverId = 1L;
+            Notification sentNotification = Notification.builder()
+                    .receiverId(receiverId)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.SENT)
+                    .referenceId(1L)
+                    .referenceType("ORDER")
+                    .idempotencyKey("sent-key")
+                    .retryCount(0)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build();
+            notificationJpaRepository.save(sentNotification);
+            notificationService.register(new NotificationCreateRequest(receiverId, NotificationType.PAYMENT_CONFIRMED, NotificationChannel.IN_APP, 2L, "PAYMENT", null));
+
+            // act
+            PageResponse<NotificationInfo.ListItem> result = notificationService.findByReceiverId(receiverId, false, PageRequest.of(0, 20));
+
+            // assert
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.content().get(0).status()).isEqualTo(NotificationStatus.SENT);
+        }
+
+        @DisplayName("readFilter가 true이면 READ 상태의 알림만 반환한다.")
+        @Test
+        void returnsReadNotificationsOnly_whenReadFilterIsTrue() {
+            // arrange
+            Long receiverId = 1L;
+            Notification readNotification = Notification.builder()
+                    .receiverId(receiverId)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.READ)
+                    .referenceId(1L)
+                    .referenceType("ORDER")
+                    .idempotencyKey("read-key")
+                    .retryCount(0)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build();
+            notificationJpaRepository.save(readNotification);
+            notificationService.register(new NotificationCreateRequest(receiverId, NotificationType.PAYMENT_CONFIRMED, NotificationChannel.IN_APP, 2L, "PAYMENT", null));
+
+            // act
+            PageResponse<NotificationInfo.ListItem> result = notificationService.findByReceiverId(receiverId, true, PageRequest.of(0, 20));
+
+            // assert
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.content().get(0).status()).isEqualTo(NotificationStatus.READ);
+        }
+
+        @DisplayName("알림이 없는 수신자로 조회하면 빈 목록을 반환한다.")
+        @Test
+        void returnsEmptyList_whenNoNotificationsExist() {
+            // arrange
+            Long receiverId = 999L;
+
+            // act
+            PageResponse<NotificationInfo.ListItem> result = notificationService.findByReceiverId(receiverId, null, PageRequest.of(0, 20));
+
+            // assert
+            assertThat(result.content()).isEmpty();
+            assertThat(result.totalElements()).isEqualTo(0);
+        }
+
+        @DisplayName("다른 수신자의 알림은 결과에 포함되지 않는다.")
+        @Test
+        void returnsOnlyTargetReceiverNotifications() {
+            // arrange
+            notificationService.register(new NotificationCreateRequest(1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL, 1L, "ORDER", null));
+            notificationService.register(new NotificationCreateRequest(2L, NotificationType.PAYMENT_CONFIRMED, NotificationChannel.IN_APP, 2L, "PAYMENT", null));
+
+            // act
+            PageResponse<NotificationInfo.ListItem> result = notificationService.findByReceiverId(1L, null, PageRequest.of(0, 20));
+
+            // assert
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.content().get(0).notificationType()).isEqualTo(NotificationType.ENROLLMENT_COMPLETE);
+        }
+    }
+}

--- a/src/test/java/com/becnotificationsystem/domain/notification/NotificationTest.java
+++ b/src/test/java/com/becnotificationsystem/domain/notification/NotificationTest.java
@@ -1,0 +1,168 @@
+package com.becnotificationsystem.domain.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class NotificationTest {
+
+    @DisplayName("Notification 객체를 생성할 때,")
+    @Nested
+    class Create {
+
+        @DisplayName("모든 필드가 올바르게 주어지면 PENDING 상태로 생성된다.")
+        @Test
+        void createsNotification_whenAllFieldsAreValid() {
+            // arrange
+            Long receiverId = 1L;
+            NotificationType type = NotificationType.ENROLLMENT_COMPLETE;
+            NotificationChannel channel = NotificationChannel.EMAIL;
+            Long referenceId = 100L;
+            String referenceType = "ORDER";
+            String idempotencyKey = "test-key";
+
+            // act
+            Notification notification = Notification.of(receiverId, type, channel, referenceId, referenceType, idempotencyKey, null);
+
+            // assert
+            assertAll(
+                    () -> assertThat(notification.getReceiverId()).isEqualTo(receiverId),
+                    () -> assertThat(notification.getNotificationType()).isEqualTo(type),
+                    () -> assertThat(notification.getChannel()).isEqualTo(channel),
+                    () -> assertThat(notification.getReferenceId()).isEqualTo(referenceId),
+                    () -> assertThat(notification.getReferenceType()).isEqualTo(referenceType),
+                    () -> assertThat(notification.getIdempotencyKey()).isEqualTo(idempotencyKey),
+                    () -> assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING),
+                    () -> assertThat(notification.getRetryCount()).isEqualTo(0),
+                    () -> assertThat(notification.getMaxRetryCount()).isEqualTo(3),
+                    () -> assertThat(notification.isDeleted()).isFalse(),
+                    () -> assertThat(notification.getScheduledAt()).isNull()
+            );
+        }
+
+        @DisplayName("scheduledAt이 null이어도 정상적으로 생성된다.")
+        @Test
+        void createsNotification_whenScheduledAtIsNull() {
+            // arrange & act
+            Notification notification = Notification.of(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    100L, "ORDER", "key", null
+            );
+
+            // assert
+            assertThat(notification.getScheduledAt()).isNull();
+            assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING);
+        }
+    }
+
+    @DisplayName("멱등성 키를 생성할 때,")
+    @Nested
+    class GenerateIdempotencyKey {
+
+        @DisplayName("동일한 파라미터로 호출하면 항상 같은 키를 반환한다.")
+        @Test
+        void returnsSameKey_whenSameParametersGiven() {
+            // arrange
+            Long receiverId = 1L;
+            NotificationType type = NotificationType.ENROLLMENT_COMPLETE;
+            Long referenceId = 100L;
+            String referenceType = "ORDER";
+            NotificationChannel channel = NotificationChannel.EMAIL;
+
+            // act
+            String key1 = Notification.generateIdempotencyKey(receiverId, type, referenceId, referenceType, channel);
+            String key2 = Notification.generateIdempotencyKey(receiverId, type, referenceId, referenceType, channel);
+
+            // assert
+            assertThat(key1).isEqualTo(key2);
+        }
+
+        @DisplayName("receiverId가 다르면 다른 키를 반환한다.")
+        @Test
+        void returnsDifferentKey_whenReceiverIdDiffers() {
+            // arrange
+            NotificationType type = NotificationType.ENROLLMENT_COMPLETE;
+            Long referenceId = 100L;
+            String referenceType = "ORDER";
+            NotificationChannel channel = NotificationChannel.EMAIL;
+
+            // act
+            String key1 = Notification.generateIdempotencyKey(1L, type, referenceId, referenceType, channel);
+            String key2 = Notification.generateIdempotencyKey(2L, type, referenceId, referenceType, channel);
+
+            // assert
+            assertThat(key1).isNotEqualTo(key2);
+        }
+
+        @DisplayName("notificationType이 다르면 다른 키를 반환한다.")
+        @Test
+        void returnsDifferentKey_whenNotificationTypeDiffers() {
+            // arrange
+            Long receiverId = 1L;
+            Long referenceId = 100L;
+            String referenceType = "ORDER";
+            NotificationChannel channel = NotificationChannel.EMAIL;
+
+            // act
+            String key1 = Notification.generateIdempotencyKey(receiverId, NotificationType.ENROLLMENT_COMPLETE, referenceId, referenceType, channel);
+            String key2 = Notification.generateIdempotencyKey(receiverId, NotificationType.PAYMENT_CONFIRMED, referenceId, referenceType, channel);
+
+            // assert
+            assertThat(key1).isNotEqualTo(key2);
+        }
+
+        @DisplayName("referenceId가 다르면 다른 키를 반환한다.")
+        @Test
+        void returnsDifferentKey_whenReferenceIdDiffers() {
+            // arrange
+            Long receiverId = 1L;
+            NotificationType type = NotificationType.ENROLLMENT_COMPLETE;
+            String referenceType = "ORDER";
+            NotificationChannel channel = NotificationChannel.EMAIL;
+
+            // act
+            String key1 = Notification.generateIdempotencyKey(receiverId, type, 100L, referenceType, channel);
+            String key2 = Notification.generateIdempotencyKey(receiverId, type, 200L, referenceType, channel);
+
+            // assert
+            assertThat(key1).isNotEqualTo(key2);
+        }
+
+        @DisplayName("referenceType이 다르면 다른 키를 반환한다.")
+        @Test
+        void returnsDifferentKey_whenReferenceTypeDiffers() {
+            // arrange
+            Long receiverId = 1L;
+            NotificationType type = NotificationType.ENROLLMENT_COMPLETE;
+            Long referenceId = 100L;
+            NotificationChannel channel = NotificationChannel.EMAIL;
+
+            // act
+            String key1 = Notification.generateIdempotencyKey(receiverId, type, referenceId, "ORDER", channel);
+            String key2 = Notification.generateIdempotencyKey(receiverId, type, referenceId, "PAYMENT", channel);
+
+            // assert
+            assertThat(key1).isNotEqualTo(key2);
+        }
+
+        @DisplayName("channel이 다르면 다른 키를 반환한다.")
+        @Test
+        void returnsDifferentKey_whenChannelDiffers() {
+            // arrange
+            Long receiverId = 1L;
+            NotificationType type = NotificationType.ENROLLMENT_COMPLETE;
+            Long referenceId = 100L;
+            String referenceType = "ORDER";
+
+            // act
+            String key1 = Notification.generateIdempotencyKey(receiverId, type, referenceId, referenceType, NotificationChannel.EMAIL);
+            String key2 = Notification.generateIdempotencyKey(receiverId, type, referenceId, referenceType, NotificationChannel.IN_APP);
+
+            // assert
+            assertThat(key1).isNotEqualTo(key2);
+        }
+    }
+}

--- a/src/test/java/com/becnotificationsystem/interfaces/api/notification/NotificationControllerE2ETest.java
+++ b/src/test/java/com/becnotificationsystem/interfaces/api/notification/NotificationControllerE2ETest.java
@@ -1,0 +1,211 @@
+package com.becnotificationsystem.interfaces.api.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.becnotificationsystem.application.notification.NotificationInfo;
+import com.becnotificationsystem.application.notification.NotificationRepository;
+import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
+import com.becnotificationsystem.domain.notification.NotificationType;
+import com.becnotificationsystem.global.common.response.CommonApiResponse;
+import com.becnotificationsystem.global.common.response.PageResponse;
+import com.becnotificationsystem.support.IntegrationTest;
+import com.becnotificationsystem.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class NotificationControllerE2ETest extends IntegrationTest {
+
+    private static final String ENDPOINT = "/api/v1/notifications";
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/notifications - 알림 등록")
+    @Nested
+    class Register {
+
+        @DisplayName("유효한 요청이 주어지면 202 Accepted와 알림 상세 정보를 반환한다.")
+        @Test
+        void returns202WithDetail_whenRequestIsValid() {
+            // arrange
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL, 100L, "ORDER", null
+            );
+
+            // act
+            ResponseEntity<CommonApiResponse<NotificationInfo.Detail>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request),
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("SUCCESS");
+
+            NotificationInfo.Detail detail = response.getBody().getData();
+            assertAll(
+                    () -> assertThat(detail.notificationId()).isNotNull(),
+                    () -> assertThat(detail.receiverId()).isEqualTo(1L),
+                    () -> assertThat(detail.status()).isEqualTo(NotificationStatus.PENDING)
+            );
+        }
+
+        @DisplayName("필수 필드가 누락되면 400 Bad Request를 반환한다.")
+        @Test
+        void returns400_whenRequiredFieldIsMissing() {
+            // arrange
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    null, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL, 100L, "ORDER", null
+            );
+
+            // act
+            ResponseEntity<CommonApiResponse<Void>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request),
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @DisplayName("동일한 요청이 중복으로 들어오면 409 Conflict를 반환한다.")
+        @Test
+        void returns409_whenDuplicateRequestGiven() {
+            // arrange
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL, 100L, "ORDER", null
+            );
+            testRestTemplate.postForEntity(ENDPOINT, request, CommonApiResponse.class);
+
+            // act
+            ResponseEntity<CommonApiResponse<Void>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.POST,
+                    new HttpEntity<>(request),
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(response.getBody().getCode()).isEqualTo("NOTIFICATION_DUPLICATE");
+        }
+    }
+
+    @DisplayName("GET /api/v1/notifications/{notificationId} - 알림 상태 조회")
+    @Nested
+    class GetStatus {
+
+        @DisplayName("존재하는 알림 ID로 조회하면 200 OK와 알림 상세 정보를 반환한다.")
+        @Test
+        void returns200WithDetail_whenNotificationExists() {
+            // arrange
+            Notification notification = Notification.of(
+                    1L, NotificationType.PAYMENT_CONFIRMED, NotificationChannel.IN_APP, 200L, "PAYMENT", "key-1", null
+            );
+            Notification saved = notificationRepository.save(notification);
+
+            // act
+            ResponseEntity<CommonApiResponse<NotificationInfo.Detail>> response = testRestTemplate.exchange(
+                    ENDPOINT + "/" + saved.getId(),
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getData().notificationId()).isEqualTo(saved.getId());
+        }
+
+        @DisplayName("존재하지 않는 알림 ID로 조회하면 404 Not Found를 반환한다.")
+        @Test
+        void returns404_whenNotificationDoesNotExist() {
+            // act
+            ResponseEntity<CommonApiResponse<Void>> response = testRestTemplate.exchange(
+                    ENDPOINT + "/9999",
+                    HttpMethod.GET,
+                    null,
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getBody().getCode()).isEqualTo("NOTIFICATION_NOT_FOUND");
+        }
+    }
+
+    @DisplayName("GET /api/v1/notifications - 알림 목록 조회")
+    @Nested
+    class GetList {
+
+        @DisplayName("X-User-Id 헤더와 함께 요청하면 해당 수신자의 알림 목록을 반환한다.")
+        @Test
+        void returnsNotificationList_forUser() {
+            // arrange
+            Long userId = 1L;
+            notificationRepository.save(Notification.of(userId, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL, 1L, "ORDER", "key-1", null));
+            notificationRepository.save(Notification.of(userId, NotificationType.PAYMENT_CONFIRMED, NotificationChannel.IN_APP, 2L, "PAYMENT", "key-2", null));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-User-Id", userId.toString());
+
+            // act
+            ResponseEntity<CommonApiResponse<PageResponse<NotificationInfo.ListItem>>> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    new ParameterizedTypeReference<>() {}
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getData().content()).hasSize(2);
+        }
+
+        @DisplayName("X-User-Id 헤더가 누락되면 400 Bad Request를 반환한다.")
+        @Test
+        void returns400_whenUserIdHeaderIsMissing() {
+            // act
+            ResponseEntity<String> response = testRestTemplate.exchange(
+                    ENDPOINT,
+                    HttpMethod.GET,
+                    null,
+                    String.class
+            );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/src/test/java/com/becnotificationsystem/support/IntegrationTest.java
+++ b/src/test/java/com/becnotificationsystem/support/IntegrationTest.java
@@ -1,0 +1,7 @@
+package com.becnotificationsystem.support;
+
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+public abstract class IntegrationTest {
+}

--- a/src/test/java/com/becnotificationsystem/utils/DatabaseCleanUp.java
+++ b/src/test/java/com/becnotificationsystem/utils/DatabaseCleanUp.java
@@ -1,0 +1,46 @@
+package com.becnotificationsystem.utils;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class DatabaseCleanUp implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final List<String> tableNames = new ArrayList<>();
+
+    @Override
+    public void afterPropertiesSet() {
+        entityManager.getMetamodel().getEntities().stream()
+                .filter(entity -> entity.getJavaType().getAnnotation(Entity.class) != null)
+                .map(entity -> {
+                    Table tableAnnotation = entity.getJavaType().getAnnotation(Table.class);
+                    return (tableAnnotation != null && !tableAnnotation.name().isEmpty())
+                            ? tableAnnotation.name()
+                            : entity.getName().toLowerCase();
+                })
+                .forEach(tableNames::add);
+    }
+
+    @Transactional
+    public void truncateAllTables() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String table : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
+        }
+
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
1. **Notification 엔티티 설계**
   - `Notification` — JPA 엔티티, `BaseEntity` 상속
   - `NotificationChannel`, `NotificationStatus`, `NotificationType` — 도메인 enum 추가

2. **에러 코드 및 공통 응답 보완**
   - `ErrorCode` — 알림 관련 에러 코드 추가 (`NOTIFICATION_NOT_FOUND`, `NOTIFICATION_DUPLICATE` 등)
   - `CommonApiResponse` — 응답 형식 수정
   - `PageResponse<T>` — 페이징 응답 래퍼 추가

3. **알림 발송 요청 등록 API** 
   - `POST /api/v1/notifications`
   - `NotificationCreateRequest` — `@Valid` 기반 요청 검증
   - 멱등성 키 기반 중복 방지 → 중복 시 409 Conflict

4. **알림 상태 조회 API** 
    - `GET /api/v1/notifications/{notificationId}`

5. **사용자 알림 목록 조회 API** `GET /api/v1/notifications`
   - `X-User-Id` 헤더로 수신자 식별
   - `isRead` 파라미터로 읽음/안읽음 필터 지원

6. **테스트 코드 작성**
   - 단위 테스트: `NotificationTest` (8개)
   - 통합 테스트: `NotificationServiceIntegrationTest` (10개)
   - E2E 테스트: `NotificationControllerE2ETest` (7개)

## 🔗 관련 이슈
#2 
