### PR TITLE
feat: 알림 비동기 발송 처리 

### DIFF
--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationCreatedEvent.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationCreatedEvent.java
@@ -1,0 +1,8 @@
+package com.becnotificationsystem.application.notification;
+
+public record NotificationCreatedEvent(Long notificationId) {
+
+    public static NotificationCreatedEvent of(Long notificationId) {
+        return new NotificationCreatedEvent(notificationId);
+    }
+}

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
@@ -2,6 +2,8 @@ package com.becnotificationsystem.application.notification;
 
 import com.becnotificationsystem.domain.notification.Notification;
 import com.becnotificationsystem.domain.notification.NotificationStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,5 +18,13 @@ public interface NotificationRepository {
             Long receiverId, NotificationStatus status, Pageable pageable);
 
     Page<Notification> findByReceiverIdAndDeletedFalse(Long receiverId, Pageable pageable);
+
+    int compareAndSwap(Long id, NotificationStatus expectedStatus, NotificationStatus newStatus);
+
+    List<Notification> findByStatusAndDeletedFalse(NotificationStatus status);
+
+    List<Notification> findByStatusAndUpdatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before);
+
+    List<Notification> findByStatusAndCreatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before);
 
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationSender.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationSender.java
@@ -1,0 +1,11 @@
+package com.becnotificationsystem.application.notification;
+
+import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+
+public interface NotificationSender {
+
+    NotificationChannel support();
+
+    void send(Notification notification);
+}

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
@@ -6,18 +6,24 @@ import com.becnotificationsystem.global.common.response.PageResponse;
 import com.becnotificationsystem.global.exception.BusinessException;
 import com.becnotificationsystem.global.exception.ErrorCode;
 import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final List<NotificationSender> senders;
 
     @Transactional
     public NotificationInfo.Detail register(NotificationCreateRequest request) {
@@ -39,7 +45,9 @@ public class NotificationService {
                 request.scheduledAt()
         );
 
-        return NotificationInfo.Detail.from(notificationRepository.save(notification));
+        NotificationInfo.Detail result = NotificationInfo.Detail.from(notificationRepository.save(notification));
+        eventPublisher.publishEvent(NotificationCreatedEvent.of(result.notificationId()));
+        return result;
     }
 
     public NotificationInfo.Detail findById(Long notificationId) {
@@ -61,6 +69,42 @@ public class NotificationService {
         }
 
         return PageResponse.from(notificationPage.map(n -> NotificationInfo.ListItem.from(n, null)));
+    }
+
+    @Transactional
+    public void process(Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndDeletedFalse(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.isProcessable()) {
+            log.debug("처리 불가능한 상태의 알림입니다. notificationId={}, status={}", notificationId, notification.getStatus());
+            return;
+        }
+
+        int updated = notificationRepository.compareAndSwap(notificationId, notification.getStatus(), NotificationStatus.PROCESSING);
+        if (updated == 0) {
+            log.debug("다른 인스턴스가 이미 처리 중입니다. notificationId={}", notificationId);
+            return;
+        }
+
+        notification.startProcessing();
+
+        NotificationSender sender = senders.stream()
+                .filter(s -> s.support() == notification.getChannel())
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_CHANNEL_NOT_SUPPORTED));
+
+        try {
+            sender.send(notification);
+            notification.markAsSent();
+        } catch (Exception e) {
+            notification.markAsFailed(e.getMessage());
+            if (!notification.canRetry()) {
+                notification.markAsDeadLetter();
+            }
+        }
+
+        notificationRepository.save(notification);
     }
 
 }

--- a/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
@@ -100,6 +100,37 @@ public class Notification extends BaseEntity {
                 .build();
     }
 
+    public boolean isProcessable() {
+        return status == NotificationStatus.PENDING || status == NotificationStatus.FAILED;
+    }
+
+    public void startProcessing() {
+        this.status = NotificationStatus.PROCESSING;
+    }
+
+    public void markAsSent() {
+        this.status = NotificationStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void markAsFailed(String reason) {
+        this.retryCount++;
+        this.failureReason = reason;
+        this.status = NotificationStatus.FAILED;
+    }
+
+    public void markAsDeadLetter() {
+        this.status = NotificationStatus.DEAD_LETTER;
+    }
+
+    public boolean canRetry() {
+        return retryCount < maxRetryCount;
+    }
+
+    public void resetToPending() {
+        this.status = NotificationStatus.PENDING;
+    }
+
     public static String generateIdempotencyKey(Long receiverId, NotificationType notificationType,
                                                 Long referenceId, String referenceType,
                                                 NotificationChannel channel) {

--- a/src/main/java/com/becnotificationsystem/global/config/AsyncConfig.java
+++ b/src/main/java/com/becnotificationsystem/global/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.becnotificationsystem.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+@EnableScheduling
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("notification-async-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/EmailNotificationSender.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/EmailNotificationSender.java
@@ -1,0 +1,23 @@
+package com.becnotificationsystem.infrastructure.notification;
+
+import com.becnotificationsystem.application.notification.NotificationSender;
+import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class EmailNotificationSender implements NotificationSender {
+
+    @Override
+    public NotificationChannel support() {
+        return NotificationChannel.EMAIL;
+    }
+
+    @Override
+    public void send(Notification notification) {
+        log.info("[EMAIL] notificationId={}, receiverId={}, type={}",
+                notification.getId(), notification.getReceiverId(), notification.getNotificationType());
+    }
+}

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/InAppNotificationSender.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/InAppNotificationSender.java
@@ -1,0 +1,23 @@
+package com.becnotificationsystem.infrastructure.notification;
+
+import com.becnotificationsystem.application.notification.NotificationSender;
+import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class InAppNotificationSender implements NotificationSender {
+
+    @Override
+    public NotificationChannel support() {
+        return NotificationChannel.IN_APP;
+    }
+
+    @Override
+    public void send(Notification notification) {
+        log.info("[IN_APP] notificationId={}, receiverId={}, type={}",
+                notification.getId(), notification.getReceiverId(), notification.getNotificationType());
+    }
+}

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
@@ -2,12 +2,23 @@ package com.becnotificationsystem.infrastructure.notification;
 
 import com.becnotificationsystem.domain.notification.Notification;
 import com.becnotificationsystem.domain.notification.NotificationStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
+
+    @Modifying
+    @Query("UPDATE Notification n SET n.status = :newStatus WHERE n.id = :id AND n.status = :expectedStatus")
+    int compareAndSwap(@Param("id") Long id,
+                       @Param("expectedStatus") NotificationStatus expectedStatus,
+                       @Param("newStatus") NotificationStatus newStatus);
 
     Optional<Notification> findByIdAndDeletedFalse(Long id);
 
@@ -15,5 +26,11 @@ public interface NotificationJpaRepository extends JpaRepository<Notification, L
             Long receiverId, NotificationStatus status, Pageable pageable);
 
     Page<Notification> findByReceiverIdAndDeletedFalse(Long receiverId, Pageable pageable);
+
+    List<Notification> findByStatusAndDeletedFalse(NotificationStatus status);
+
+    List<Notification> findByStatusAndUpdatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before);
+
+    List<Notification> findByStatusAndCreatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before);
 
 }

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.becnotificationsystem.domain.notification.Notification;
 import com.becnotificationsystem.domain.notification.NotificationStatus;
 import com.becnotificationsystem.global.exception.BusinessException;
 import com.becnotificationsystem.global.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -41,5 +43,25 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     @Override
     public Page<Notification> findByReceiverIdAndDeletedFalse(Long receiverId, Pageable pageable) {
         return notificationJpaRepository.findByReceiverIdAndDeletedFalse(receiverId, pageable);
+    }
+
+    @Override
+    public int compareAndSwap(Long id, NotificationStatus expectedStatus, NotificationStatus newStatus) {
+        return notificationJpaRepository.compareAndSwap(id, expectedStatus, newStatus);
+    }
+
+    @Override
+    public List<Notification> findByStatusAndDeletedFalse(NotificationStatus status) {
+        return notificationJpaRepository.findByStatusAndDeletedFalse(status);
+    }
+
+    @Override
+    public List<Notification> findByStatusAndUpdatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before) {
+        return notificationJpaRepository.findByStatusAndUpdatedAtBeforeAndDeletedFalse(status, before);
+    }
+
+    @Override
+    public List<Notification> findByStatusAndCreatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before) {
+        return notificationJpaRepository.findByStatusAndCreatedAtBeforeAndDeletedFalse(status, before);
     }
 }

--- a/src/main/java/com/becnotificationsystem/interfaces/listener/NotificationEventListener.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/listener/NotificationEventListener.java
@@ -1,0 +1,22 @@
+package com.becnotificationsystem.interfaces.listener;
+
+import com.becnotificationsystem.application.notification.NotificationService;
+import com.becnotificationsystem.application.notification.NotificationCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleNotificationCreated(NotificationCreatedEvent event) {
+        notificationService.process(event.notificationId());
+    }
+}

--- a/src/main/java/com/becnotificationsystem/interfaces/scheduler/NotificationRecoveryScheduler.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/scheduler/NotificationRecoveryScheduler.java
@@ -1,0 +1,49 @@
+package com.becnotificationsystem.interfaces.scheduler;
+
+import com.becnotificationsystem.application.notification.NotificationRepository;
+import com.becnotificationsystem.application.notification.NotificationService;
+import com.becnotificationsystem.application.notification.NotificationCreatedEvent;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationRecoveryScheduler {
+
+    private final NotificationRepository notificationRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final NotificationService notificationService;
+
+    @Scheduled(fixedDelay = 60_000)
+    public void recoverPendingNotifications() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(2);
+        notificationRepository
+                .findByStatusAndCreatedAtBeforeAndDeletedFalse(NotificationStatus.PENDING, threshold)
+                .forEach(n -> eventPublisher.publishEvent(NotificationCreatedEvent.of(n.getId())));
+    }
+
+    @Scheduled(fixedDelay = 300_000)
+    @Transactional
+    public void recoverStuckProcessingNotifications() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(5);
+        notificationRepository
+                .findByStatusAndUpdatedAtBeforeAndDeletedFalse(NotificationStatus.PROCESSING, threshold)
+                .forEach(n -> {
+                    n.resetToPending();
+                    notificationRepository.save(n);
+                    eventPublisher.publishEvent(NotificationCreatedEvent.of(n.getId()));
+                });
+    }
+
+    @Scheduled(fixedDelay = 60_000)
+    public void retryFailedNotifications() {
+        notificationRepository
+                .findByStatusAndDeletedFalse(NotificationStatus.FAILED)
+                .forEach(n -> notificationService.process(n.getId()));
+    }
+}

--- a/src/test/java/com/becnotificationsystem/application/notification/NotificationSendServiceIntegrationTest.java
+++ b/src/test/java/com/becnotificationsystem/application/notification/NotificationSendServiceIntegrationTest.java
@@ -1,0 +1,208 @@
+package com.becnotificationsystem.application.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
+import com.becnotificationsystem.domain.notification.Notification;
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
+import com.becnotificationsystem.domain.notification.NotificationType;
+import com.becnotificationsystem.global.exception.BusinessException;
+import com.becnotificationsystem.global.exception.ErrorCode;
+import com.becnotificationsystem.infrastructure.notification.EmailNotificationSender;
+import com.becnotificationsystem.infrastructure.notification.InAppNotificationSender;
+import com.becnotificationsystem.infrastructure.notification.NotificationJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NotificationSendServiceIntegrationTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Autowired
+    private NotificationJpaRepository notificationJpaRepository;
+
+    @MockitoSpyBean
+    private EmailNotificationSender emailNotificationSender;
+
+    @MockitoSpyBean
+    private InAppNotificationSender inAppNotificationSender;
+
+    @AfterEach
+    void tearDown() {
+        notificationJpaRepository.deleteAll();
+    }
+
+    private Notification savePendingNotification(NotificationChannel channel) {
+        Notification notification = Notification.of(
+                1L, NotificationType.ENROLLMENT_COMPLETE, channel,
+                100L, "ORDER",
+                Notification.generateIdempotencyKey(1L, NotificationType.ENROLLMENT_COMPLETE, 100L, "ORDER", channel),
+                null
+        );
+        return notificationJpaRepository.save(notification);
+    }
+
+    private Notification saveFailedNotification(int retryCount) {
+        Notification notification = Notification.builder()
+                .receiverId(1L)
+                .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                .channel(NotificationChannel.EMAIL)
+                .status(NotificationStatus.FAILED)
+                .referenceId(100L)
+                .referenceType("ORDER")
+                .idempotencyKey("failed-key-" + retryCount)
+                .retryCount(retryCount)
+                .maxRetryCount(3)
+                .deleted(false)
+                .build();
+        return notificationJpaRepository.save(notification);
+    }
+
+    @DisplayName("알림을 발송할 때,")
+    @Nested
+    class Process {
+
+        @DisplayName("PENDING 상태의 EMAIL 알림을 발송하면 SENT 상태가 되고 sentAt이 설정된다.")
+        @Test
+        void transitionsToSent_whenEmailNotificationIsPending() {
+            // arrange
+            Notification saved = savePendingNotification(NotificationChannel.EMAIL);
+
+            // act
+            notificationService.process(saved.getId());
+
+            // assert
+            Notification result = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertAll(
+                    () -> assertThat(result.getStatus()).isEqualTo(NotificationStatus.SENT),
+                    () -> assertThat(result.getSentAt()).isNotNull()
+            );
+        }
+
+        @DisplayName("PENDING 상태의 IN_APP 알림을 발송하면 SENT 상태가 된다.")
+        @Test
+        void transitionsToSent_whenInAppNotificationIsPending() {
+            // arrange
+            Notification saved = savePendingNotification(NotificationChannel.IN_APP);
+
+            // act
+            notificationService.process(saved.getId());
+
+            // assert
+            Notification result = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(NotificationStatus.SENT);
+        }
+
+        @DisplayName("발송 중 예외가 발생하고 재시도 가능하면 FAILED 상태가 되고 retryCount가 증가한다.")
+        @Test
+        void transitionsToFailed_whenSendThrowsAndCanRetry() {
+            // arrange
+            Notification saved = savePendingNotification(NotificationChannel.EMAIL);
+            doThrow(new RuntimeException("SMTP error")).when(emailNotificationSender).send(any());
+
+            // act
+            notificationService.process(saved.getId());
+
+            // assert
+            Notification result = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertAll(
+                    () -> assertThat(result.getStatus()).isEqualTo(NotificationStatus.FAILED),
+                    () -> assertThat(result.getRetryCount()).isEqualTo(1),
+                    () -> assertThat(result.getFailureReason()).contains("SMTP error")
+            );
+        }
+
+        @DisplayName("재시도 횟수가 maxRetryCount에 도달하면 DEAD_LETTER 상태가 된다.")
+        @Test
+        void transitionsToDeadLetter_whenRetryCountReachesMax() {
+            // arrange
+            Notification saved = saveFailedNotification(2); // maxRetryCount=3, retryCount=2 → 다음 실패 시 3 >= 3
+            doThrow(new RuntimeException("SMTP error")).when(emailNotificationSender).send(any());
+
+            // act
+            notificationService.process(saved.getId());
+
+            // assert
+            Notification result = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(NotificationStatus.DEAD_LETTER);
+        }
+
+        @DisplayName("이미 SENT 상태인 알림에 process()를 호출해도 상태가 변경되지 않는다.")
+        @Test
+        void doesNotChangeStatus_whenAlreadySent() {
+            // arrange
+            Notification notification = Notification.builder()
+                    .receiverId(1L)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.SENT)
+                    .referenceId(100L)
+                    .referenceType("ORDER")
+                    .idempotencyKey("sent-key")
+                    .retryCount(0)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build();
+            Notification saved = notificationJpaRepository.save(notification);
+
+            // act
+            notificationService.process(saved.getId());
+
+            // assert
+            Notification result = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(NotificationStatus.SENT);
+        }
+
+        @DisplayName("이미 PROCESSING 상태인 알림에 process()를 호출해도 상태가 변경되지 않는다.")
+        @Test
+        void doesNotChangeStatus_whenAlreadyProcessing() {
+            // arrange
+            Notification notification = Notification.builder()
+                    .receiverId(1L)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.PROCESSING)
+                    .referenceId(100L)
+                    .referenceType("ORDER")
+                    .idempotencyKey("processing-key")
+                    .retryCount(0)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build();
+            Notification saved = notificationJpaRepository.save(notification);
+
+            // act
+            notificationService.process(saved.getId());
+
+            // assert
+            Notification result = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertThat(result.getStatus()).isEqualTo(NotificationStatus.PROCESSING);
+        }
+
+        @DisplayName("존재하지 않는 notificationId로 호출하면 NOTIFICATION_NOT_FOUND 예외가 발생한다.")
+        @Test
+        void throwsException_whenNotificationDoesNotExist() {
+            // arrange
+            Long nonExistentId = 999L;
+
+            // act & assert
+            BusinessException exception = assertThrows(BusinessException.class, () ->
+                    notificationService.process(nonExistentId)
+            );
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/com/becnotificationsystem/application/notification/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/becnotificationsystem/application/notification/NotificationServiceIntegrationTest.java
@@ -16,6 +16,8 @@ import com.becnotificationsystem.global.exception.BusinessException;
 import com.becnotificationsystem.global.exception.ErrorCode;
 import com.becnotificationsystem.infrastructure.notification.NotificationJpaRepository;
 import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
+import com.becnotificationsystem.interfaces.listener.NotificationEventListener;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,6 +40,9 @@ class NotificationServiceIntegrationTest {
 
     @Autowired
     private NotificationJpaRepository notificationJpaRepository;
+
+    @MockitoBean
+    private NotificationEventListener notificationEventListener;
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/com/becnotificationsystem/domain/notification/NotificationTest.java
+++ b/src/test/java/com/becnotificationsystem/domain/notification/NotificationTest.java
@@ -3,6 +3,7 @@ package com.becnotificationsystem.domain.notification;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -163,6 +164,121 @@ class NotificationTest {
 
             // assert
             assertThat(key1).isNotEqualTo(key2);
+        }
+    }
+
+    @DisplayName("상태 전이 메서드를 호출할 때,")
+    @Nested
+    class StatusTransition {
+
+        private Notification createPendingNotification() {
+            return Notification.of(1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL,
+                    100L, "ORDER", "test-key", null);
+        }
+
+        @DisplayName("startProcessing()을 호출하면 PROCESSING 상태로 전이된다.")
+        @Test
+        void transitionsToProcessing_whenStartProcessingCalled() {
+            // arrange
+            Notification notification = createPendingNotification();
+
+            // act
+            notification.startProcessing();
+
+            // assert
+            assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PROCESSING);
+        }
+
+        @DisplayName("markAsSent()을 호출하면 SENT 상태가 되고 sentAt이 설정된다.")
+        @Test
+        void transitionsToSent_whenMarkAsSentCalled() {
+            // arrange
+            Notification notification = createPendingNotification();
+            notification.startProcessing();
+            LocalDateTime before = LocalDateTime.now();
+
+            // act
+            notification.markAsSent();
+
+            // assert
+            assertAll(
+                    () -> assertThat(notification.getStatus()).isEqualTo(NotificationStatus.SENT),
+                    () -> assertThat(notification.getSentAt()).isNotNull(),
+                    () -> assertThat(notification.getSentAt()).isAfterOrEqualTo(before)
+            );
+        }
+
+        @DisplayName("markAsFailed()을 호출하면 FAILED 상태가 되고 retryCount가 증가하며 failureReason이 설정된다.")
+        @Test
+        void transitionsToFailed_whenMarkAsFailedCalled() {
+            // arrange
+            Notification notification = createPendingNotification();
+            notification.startProcessing();
+
+            // act
+            notification.markAsFailed("connection timeout");
+
+            // assert
+            assertAll(
+                    () -> assertThat(notification.getStatus()).isEqualTo(NotificationStatus.FAILED),
+                    () -> assertThat(notification.getRetryCount()).isEqualTo(1),
+                    () -> assertThat(notification.getFailureReason()).isEqualTo("connection timeout")
+            );
+        }
+
+        @DisplayName("markAsDeadLetter()을 호출하면 DEAD_LETTER 상태로 전이된다.")
+        @Test
+        void transitionsToDeadLetter_whenMarkAsDeadLetterCalled() {
+            // arrange
+            Notification notification = createPendingNotification();
+            notification.startProcessing();
+            notification.markAsFailed("error");
+
+            // act
+            notification.markAsDeadLetter();
+
+            // assert
+            assertThat(notification.getStatus()).isEqualTo(NotificationStatus.DEAD_LETTER);
+        }
+
+        @DisplayName("canRetry()는 retryCount가 maxRetryCount보다 작으면 true를 반환한다.")
+        @Test
+        void returnsTrue_whenRetryCountLessThanMax() {
+            // arrange
+            Notification notification = createPendingNotification();
+
+            // act & assert
+            assertThat(notification.canRetry()).isTrue();
+        }
+
+        @DisplayName("canRetry()는 retryCount가 maxRetryCount 이상이면 false를 반환한다.")
+        @Test
+        void returnsFalse_whenRetryCountReachesMax() {
+            // arrange
+            Notification notification = createPendingNotification();
+            notification.startProcessing();
+            notification.markAsFailed("err");
+            notification.startProcessing();
+            notification.markAsFailed("err");
+            notification.startProcessing();
+            notification.markAsFailed("err");
+
+            // act & assert
+            assertThat(notification.canRetry()).isFalse();
+        }
+
+        @DisplayName("resetToPending()을 호출하면 PENDING 상태로 복구된다.")
+        @Test
+        void resetsToPending_whenResetToPendingCalled() {
+            // arrange
+            Notification notification = createPendingNotification();
+            notification.startProcessing();
+
+            // act
+            notification.resetToPending();
+
+            // assert
+            assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING);
         }
     }
 }

--- a/src/test/java/com/becnotificationsystem/interfaces/listener/NotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/becnotificationsystem/interfaces/listener/NotificationEventListenerIntegrationTest.java
@@ -1,0 +1,62 @@
+package com.becnotificationsystem.interfaces.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.becnotificationsystem.application.notification.NotificationInfo;
+import com.becnotificationsystem.application.notification.NotificationService;
+import com.becnotificationsystem.domain.notification.NotificationChannel;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
+import com.becnotificationsystem.domain.notification.NotificationType;
+import com.becnotificationsystem.infrastructure.notification.NotificationJpaRepository;
+import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NotificationEventListenerIntegrationTest {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @Autowired
+    private NotificationJpaRepository notificationJpaRepository;
+
+    @AfterEach
+    void tearDown() {
+        notificationJpaRepository.deleteAll();
+    }
+
+    @DisplayName("NotificationCreatedEvent를 수신했을 때,")
+    @Nested
+    class HandleNotificationCreated {
+
+        @DisplayName("트랜잭션 커밋 후 별도 스레드에서 발송 처리가 실행되어 알림이 SENT 상태가 된다.")
+        @Test
+        void processesNotificationAsync_afterTransactionCommit() throws InterruptedException {
+            // arrange
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL,
+                    100L, "ORDER", null
+            );
+
+            // act
+            NotificationInfo.Detail result = notificationService.register(request);
+
+            // assert — 비동기 발송 처리 완료 대기 (최대 3초, 100ms 간격 폴링)
+            NotificationStatus status = NotificationStatus.PENDING;
+            long deadline = System.currentTimeMillis() + 3_000;
+            while (System.currentTimeMillis() < deadline) {
+                status = notificationJpaRepository.findById(result.notificationId()).orElseThrow().getStatus();
+                if (status == NotificationStatus.SENT) break;
+                Thread.sleep(100);
+            }
+            assertThat(status).isEqualTo(NotificationStatus.SENT);
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
1. 비동기 발송 구조 
    - `NotificationCreatedEvent` -  알림 등록 후 발행
    - `NotificationEventListener` -  `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 조합으로 별도 스레드에서 발송 처리

2. 발송 채널 추상화
    - `NotificationSender` 인터페이스 (application단) - support() + send()
    - `EmailNotificationSender` / `InAppNotificationSender` (infrastructure단) -  채널별 구현체

3. 재시도 및 복구
    - `NotificationService.process()` -  PENDING/FAILED → PROCESSING → SENT/FAILED/DEAD_LETTER 상태 전이, canRetry() 초과 시 DEAD_LETTER 전환
    - `NotificationRecoveryScheduler` -  PENDING 이벤트 유실(1분), PROCESSING stuck(5분), FAILED 재시도(1분) 3가지 복구 전략
    
4. 다중 인스턴스 안전 
    - compareAndSwap() -  UPDATE ... WHERE status = :expectedStatus 조건부 UPDATE로 두 인스턴스가 동시에 처리 시도해도 하나만 발송하도록 보장
    
5. 테스트 코드 작성
    - `NotificationTest` -  상태 전이 도메인 메서드 7개 케이스
    - `NotificationSendServiceIntegrationTest` - process() 6개 케이스 (SENT, FAILED, DEAD_LETTER, 멱등, NOT_FOUND)
    - `NotificationEventListenerIntegrationTest` -  등록 후 비동기 발송까지 이어지는 흐름 검증

## 🔗 관련 이슈
#3 
