### PR TITLE
feat: 추가 기능 구현 

### DIFF
--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationFacade.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationFacade.java
@@ -24,6 +24,7 @@ public class NotificationFacade {
     private final TaskScheduler taskScheduler;
     private final ApplicationEventPublisher eventPublisher;
 
+    @Transactional
     public NotificationInfo.Detail register(NotificationCreateRequest request) {
         NotificationInfo.Detail result = notificationService.register(request);
         if (NotificationStatus.isPending(result.status())) {

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationFacade.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationFacade.java
@@ -1,19 +1,38 @@
 package com.becnotificationsystem.application.notification;
 
 import com.becnotificationsystem.application.sendlog.NotificationSendLogService;
+import com.becnotificationsystem.domain.notification.NotificationStatus;
 import com.becnotificationsystem.domain.sendlog.NotificationSendLog;
 import com.becnotificationsystem.domain.sendlog.SendLogResult;
+import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationFacade {
 
     private final NotificationService notificationService;
     private final NotificationSendLogService notificationSendLogService;
+    private final TaskScheduler taskScheduler;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public NotificationInfo.Detail register(NotificationCreateRequest request) {
+        NotificationInfo.Detail result = notificationService.register(request);
+        if (NotificationStatus.isPending(result.status())) {
+            eventPublisher.publishEvent(NotificationCreatedEvent.of(result.notificationId()));
+        } else {
+            scheduleTask(result.notificationId(), result.scheduledAt());
+        }
+        return result;
+    }
 
     @Transactional
     public void sendNotification(Long notificationId) {
@@ -38,5 +57,28 @@ public class NotificationFacade {
 
     public void retryFailedNotifications() {
         notificationService.findFailedIds().forEach(this::sendNotification);
+    }
+
+    public void recoverScheduledNotifications(LocalDateTime baseTime) {
+        notificationService.findAllScheduled().forEach(info -> {
+            if (info.scheduledAt().isAfter(baseTime)) {
+                scheduleTask(info.notificationId(), info.scheduledAt());
+                log.info("예약 알림 재등록: notificationId={}, scheduledAt={}", info.notificationId(), info.scheduledAt());
+            } else {
+                notificationService.scheduledToPending(info.notificationId());
+                log.info("지연된 예약 알림 즉시 처리: notificationId={}", info.notificationId());
+            }
+        });
+    }
+
+    public void sendScheduledNotifications() {
+        notificationService.findDueScheduledIds().forEach(notificationService::scheduledToPending);
+    }
+
+    private void scheduleTask(Long notificationId, LocalDateTime scheduledAt) {
+        taskScheduler.schedule(
+                () -> notificationService.scheduledToPending(notificationId),
+                scheduledAt.atZone(ZoneId.systemDefault()).toInstant()
+        );
     }
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationInfo.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationInfo.java
@@ -70,4 +70,10 @@ public class NotificationInfo {
             );
         }
     }
+
+    public record ReadResult(Long notificationId, NotificationStatus status, LocalDateTime readAt) {
+        public static ReadResult from(Notification notification) {
+            return new ReadResult(notification.getId(), notification.getStatus(), notification.getReadAt());
+        }
+    }
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationRepository.java
@@ -27,4 +27,6 @@ public interface NotificationRepository {
 
     List<Notification> findByStatusAndCreatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before);
 
+    List<Notification> findDueScheduledNotifications(LocalDateTime now);
+
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
@@ -46,9 +46,7 @@ public class NotificationService {
                 request.scheduledAt()
         );
 
-        NotificationInfo.Detail result = NotificationInfo.Detail.from(notificationRepository.save(notification));
-        eventPublisher.publishEvent(NotificationCreatedEvent.of(result.notificationId()));
-        return result;
+        return NotificationInfo.Detail.from(notificationRepository.save(notification));
     }
 
     @Transactional(readOnly = true)
@@ -150,4 +148,28 @@ public class NotificationService {
                 .stream().map(Notification::getId).toList();
     }
 
+    @Transactional
+    public void scheduledToPending(Long notificationId) {
+        Notification notification = notificationRepository.findByIdAndDeletedFalse(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        if (!NotificationStatus.isScheduled(notification.getStatus())) {
+            log.debug("예약 알림이 SCHEDULED 상태가 아닙니다. notificationId={}, status={}", notificationId, notification.getStatus());
+            return;
+        }
+        notification.markAsPending();
+        notificationRepository.save(notification);
+        eventPublisher.publishEvent(NotificationCreatedEvent.of(notificationId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationInfo.Detail> findAllScheduled() {
+        return notificationRepository.findByStatusAndDeletedFalse(NotificationStatus.SCHEDULED)
+                .stream().map(NotificationInfo.Detail::from).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> findDueScheduledIds() {
+        return notificationRepository.findDueScheduledNotifications(LocalDateTime.now())
+                .stream().map(Notification::getId).toList();
+    }
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
@@ -172,4 +172,24 @@ public class NotificationService {
         return notificationRepository.findDueScheduledNotifications(LocalDateTime.now())
                 .stream().map(Notification::getId).toList();
     }
+
+    @Transactional
+    public NotificationInfo.ReadResult markAsRead(Long notificationId, Long receiverId, LocalDateTime readAt) {
+        Notification notification = notificationRepository.findByIdAndDeletedFalse(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (NotificationChannel.isEmail(notification.getChannel())) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_CHANNEL_NOT_SUPPORTED);
+        }
+        if (!notification.matchesReceiver(receiverId)) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_ACCESS_DENIED);
+        }
+
+        int updated = notificationRepository.compareAndSwap(notificationId, NotificationStatus.SENT, NotificationStatus.READ);
+        if (updated > 0) {
+            notification.markAsRead(readAt);
+        }
+
+        return NotificationInfo.ReadResult.from(notification);
+    }
 }

--- a/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
+++ b/src/main/java/com/becnotificationsystem/application/notification/NotificationService.java
@@ -192,4 +192,22 @@ public class NotificationService {
 
         return NotificationInfo.ReadResult.from(notification);
     }
+
+    @Transactional
+    public NotificationInfo.Detail manualRetry(Long notificationId, Long receiverId) {
+        Notification notification = notificationRepository.findByIdAndDeletedFalse(notificationId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!NotificationStatus.isDeadLetter(notification.getStatus())) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_RETRY_NOT_ALLOWED);
+        }
+        if (!notification.matchesReceiver(receiverId)) {
+            throw new BusinessException(ErrorCode.NOTIFICATION_ACCESS_DENIED);
+        }
+
+        notification.resetToPending();
+        NotificationInfo.Detail result = NotificationInfo.Detail.from(notificationRepository.save(notification));
+        eventPublisher.publishEvent(NotificationCreatedEvent.of(notificationId));
+        return result;
+    }
 }

--- a/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -83,8 +84,8 @@ public class Notification extends BaseEntity {
     }
 
     public static Notification of(Long receiverId, NotificationType notificationType, NotificationChannel channel,
-                                   Long referenceId, String referenceType, String idempotencyKey,
-                                   LocalDateTime scheduledAt) {
+                                  Long referenceId, String referenceType, String idempotencyKey,
+                                  LocalDateTime scheduledAt) {
         NotificationStatus initialStatus = (scheduledAt != null && scheduledAt.isAfter(LocalDateTime.now()))
                 ? NotificationStatus.SCHEDULED
                 : NotificationStatus.PENDING;
@@ -137,6 +138,15 @@ public class Notification extends BaseEntity {
 
     public void resetToPending() {
         this.status = NotificationStatus.PENDING;
+    }
+
+    public void markAsRead(LocalDateTime readAt) {
+        this.status = NotificationStatus.READ;
+        this.readAt = readAt;
+    }
+
+    public boolean matchesReceiver(Long receiverId) {
+        return Objects.equals(this.receiverId, receiverId);
     }
 
     public static String generateIdempotencyKey(Long receiverId, NotificationType notificationType,

--- a/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/Notification.java
@@ -85,11 +85,15 @@ public class Notification extends BaseEntity {
     public static Notification of(Long receiverId, NotificationType notificationType, NotificationChannel channel,
                                    Long referenceId, String referenceType, String idempotencyKey,
                                    LocalDateTime scheduledAt) {
+        NotificationStatus initialStatus = (scheduledAt != null && scheduledAt.isAfter(LocalDateTime.now()))
+                ? NotificationStatus.SCHEDULED
+                : NotificationStatus.PENDING;
+
         return Notification.builder()
                 .receiverId(receiverId)
                 .notificationType(notificationType)
                 .channel(channel)
-                .status(NotificationStatus.PENDING)
+                .status(initialStatus)
                 .referenceId(referenceId)
                 .referenceType(referenceType)
                 .idempotencyKey(idempotencyKey)
@@ -98,6 +102,10 @@ public class Notification extends BaseEntity {
                 .scheduledAt(scheduledAt)
                 .deleted(false)
                 .build();
+    }
+
+    public void markAsPending() {
+        this.status = NotificationStatus.PENDING;
     }
 
     public boolean isProcessable() {

--- a/src/main/java/com/becnotificationsystem/domain/notification/NotificationChannel.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/NotificationChannel.java
@@ -2,5 +2,9 @@ package com.becnotificationsystem.domain.notification;
 
 public enum NotificationChannel {
     EMAIL,
-    IN_APP
+    IN_APP;
+
+    public static boolean isEmail(NotificationChannel channel) {
+        return channel == EMAIL;
+    }
 }

--- a/src/main/java/com/becnotificationsystem/domain/notification/NotificationStatus.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/NotificationStatus.java
@@ -16,4 +16,8 @@ public enum NotificationStatus {
     public static boolean isScheduled(NotificationStatus status) {
         return status == NotificationStatus.SCHEDULED;
     }
+
+    public static boolean isDeadLetter(NotificationStatus status) {
+        return status == NotificationStatus.DEAD_LETTER;
+    }
 }

--- a/src/main/java/com/becnotificationsystem/domain/notification/NotificationStatus.java
+++ b/src/main/java/com/becnotificationsystem/domain/notification/NotificationStatus.java
@@ -1,10 +1,19 @@
 package com.becnotificationsystem.domain.notification;
 
 public enum NotificationStatus {
+    SCHEDULED,
     PENDING,
     PROCESSING,
     SENT,
     FAILED,
     DEAD_LETTER,
-    READ
+    READ;
+
+    public static boolean isPending(NotificationStatus status) {
+        return status == NotificationStatus.PENDING;
+    }
+
+    public static boolean isScheduled(NotificationStatus status) {
+        return status == NotificationStatus.SCHEDULED;
+    }
 }

--- a/src/main/java/com/becnotificationsystem/global/config/AsyncConfig.java
+++ b/src/main/java/com/becnotificationsystem/global/config/AsyncConfig.java
@@ -1,11 +1,14 @@
 package com.becnotificationsystem.global.config;
 
 import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableAsync
@@ -21,5 +24,14 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setThreadNamePrefix("notification-async-");
         executor.initialize();
         return executor;
+    }
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.setThreadNamePrefix("notification-dynamic-scheduler-");
+        scheduler.initialize();
+        return scheduler;
     }
 }

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationJpaRepository.java
@@ -33,4 +33,7 @@ public interface NotificationJpaRepository extends JpaRepository<Notification, L
 
     List<Notification> findByStatusAndCreatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before);
 
+    List<Notification> findByStatusAndScheduledAtLessThanEqualAndDeletedFalse(
+            NotificationStatus status, LocalDateTime scheduledAt);
+
 }

--- a/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
+++ b/src/main/java/com/becnotificationsystem/infrastructure/notification/NotificationRepositoryImpl.java
@@ -64,4 +64,10 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     public List<Notification> findByStatusAndCreatedAtBeforeAndDeletedFalse(NotificationStatus status, LocalDateTime before) {
         return notificationJpaRepository.findByStatusAndCreatedAtBeforeAndDeletedFalse(status, before);
     }
+
+    @Override
+    public List<Notification> findDueScheduledNotifications(LocalDateTime now) {
+        return notificationJpaRepository.findByStatusAndScheduledAtLessThanEqualAndDeletedFalse(
+                NotificationStatus.SCHEDULED, now);
+    }
 }

--- a/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
@@ -7,6 +7,7 @@ import com.becnotificationsystem.application.notification.NotificationService;
 import com.becnotificationsystem.global.common.response.CommonApiResponse;
 import com.becnotificationsystem.global.common.response.PageResponse;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -41,5 +42,13 @@ public class NotificationController {
             @RequestParam(required = false) Boolean readFilter,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return CommonApiResponse.success(notificationService.findByReceiverId(userId, readFilter, pageable), "조회 성공");
+    }
+
+    @PatchMapping("/{notificationId}/read")
+    public CommonApiResponse<NotificationInfo.ReadResult> markAsRead(
+            @PathVariable Long notificationId,
+            @RequestHeader("X-User-Id") Long userId) {
+        LocalDateTime readAt = LocalDateTime.now();
+        return CommonApiResponse.success(notificationService.markAsRead(notificationId, userId, readAt), "읽음 처리 성공");
     }
 }

--- a/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
@@ -51,4 +51,11 @@ public class NotificationController {
         LocalDateTime readAt = LocalDateTime.now();
         return CommonApiResponse.success(notificationService.markAsRead(notificationId, userId, readAt), "읽음 처리 성공");
     }
+
+    @PostMapping("/{notificationId}/retry")
+    public CommonApiResponse<NotificationInfo.Detail> manualRetry(
+            @PathVariable Long notificationId,
+            @RequestHeader("X-User-Id") Long userId) {
+        return CommonApiResponse.success(notificationService.manualRetry(notificationId, userId), "재시도 요청 성공");
+    }
 }

--- a/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationController.java
@@ -1,5 +1,6 @@
 package com.becnotificationsystem.interfaces.api.notification;
 
+import com.becnotificationsystem.application.notification.NotificationFacade;
 import com.becnotificationsystem.application.notification.NotificationInfo;
 import com.becnotificationsystem.application.notification.NotificationInfo.ListItem;
 import com.becnotificationsystem.application.notification.NotificationService;
@@ -18,13 +19,14 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class NotificationController {
 
+    private final NotificationFacade notificationFacade;
     private final NotificationService notificationService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.ACCEPTED)
     public CommonApiResponse<NotificationInfo.Detail> register(
             @Valid @RequestBody NotificationCreateRequest request) {
-        return CommonApiResponse.success(notificationService.register(request), "알림 발송 요청이 접수되었습니다.");
+        return CommonApiResponse.success(notificationFacade.register(request), "알림 발송 요청이 접수되었습니다.");
     }
 
     @GetMapping("/{notificationId}")

--- a/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationCreateRequest.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/api/notification/NotificationCreateRequest.java
@@ -2,6 +2,7 @@ package com.becnotificationsystem.interfaces.api.notification;
 
 import com.becnotificationsystem.domain.notification.NotificationChannel;
 import com.becnotificationsystem.domain.notification.NotificationType;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -23,5 +24,6 @@ public record NotificationCreateRequest(
         @NotBlank(message = "참조 타입은 필수입니다.")
         String referenceType,
 
+        @Future(message = "예약 발송 시각은 현재 시각 이후여야 합니다.")
         LocalDateTime scheduledAt
 ) {}

--- a/src/main/java/com/becnotificationsystem/interfaces/scheduler/NotificationScheduledSendScheduler.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/scheduler/NotificationScheduledSendScheduler.java
@@ -1,0 +1,18 @@
+package com.becnotificationsystem.interfaces.scheduler;
+
+import com.becnotificationsystem.application.notification.NotificationFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduledSendScheduler {
+
+    private final NotificationFacade notificationFacade;
+
+    @Scheduled(fixedDelay = 600_000)
+    public void sendScheduledNotifications() {
+        notificationFacade.sendScheduledNotifications();
+    }
+}

--- a/src/main/java/com/becnotificationsystem/interfaces/scheduler/NotificationStartupScheduler.java
+++ b/src/main/java/com/becnotificationsystem/interfaces/scheduler/NotificationStartupScheduler.java
@@ -1,0 +1,21 @@
+package com.becnotificationsystem.interfaces.scheduler;
+
+import com.becnotificationsystem.application.notification.NotificationFacade;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationStartupScheduler {
+
+    private final NotificationFacade notificationFacade;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        LocalDateTime now = LocalDateTime.now();
+        notificationFacade.recoverScheduledNotifications(now);
+    }
+}

--- a/src/test/java/com/becnotificationsystem/application/notification/NotificationFacadeIntegrationTest.java
+++ b/src/test/java/com/becnotificationsystem/application/notification/NotificationFacadeIntegrationTest.java
@@ -3,8 +3,11 @@ package com.becnotificationsystem.application.notification;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.becnotificationsystem.domain.notification.Notification;
@@ -17,8 +20,11 @@ import com.becnotificationsystem.infrastructure.notification.EmailNotificationSe
 import com.becnotificationsystem.infrastructure.notification.InAppNotificationSender;
 import com.becnotificationsystem.infrastructure.notification.NotificationJpaRepository;
 import com.becnotificationsystem.infrastructure.sendlog.NotificationSendLogJpaRepository;
+import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
 import com.becnotificationsystem.interfaces.listener.NotificationEventListener;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -57,6 +64,9 @@ class NotificationFacadeIntegrationTest {
 
     @MockitoBean
     private NotificationEventListener notificationEventListener;
+
+    @MockitoBean
+    private TaskScheduler taskScheduler;
 
     @AfterEach
     void tearDown() {
@@ -162,6 +172,120 @@ class NotificationFacadeIntegrationTest {
                 () -> assertThat(logs.get(0).getResult()).isEqualTo(SendLogResult.FAILURE),
                 () -> assertThat(logs.get(0).getFailureReason()).contains("SMTP error")
         );
+    }
+
+    @Test
+    @DisplayName("register() — scheduledAt이 미래이면 TaskScheduler.schedule이 호출되고 즉시 이벤트 리스너는 호출되지 않는다")
+    void schedulesTask_whenRegisterWithFutureScheduledAt() {
+        NotificationCreateRequest request = new NotificationCreateRequest(
+                        1L,
+                        NotificationType.ENROLLMENT_COMPLETE,
+                        NotificationChannel.IN_APP,
+                        11_000L,
+                        "FACADE_SCHEDULE",
+                        LocalDateTime.now().plusHours(3)
+                );
+
+        notificationFacade.register(request);
+
+        verify(taskScheduler, times(1)).schedule(any(Runnable.class), any(Instant.class));
+        verify(notificationEventListener, never()).handleNotificationCreated(any());
+    }
+
+    @Test
+    @DisplayName("register() — scheduledAt이 null이면 TaskScheduler를 쓰지 않고 커밋 후 이벤트가 발행된다")
+    void publishesEvent_whenRegisterImmediate() {
+        NotificationCreateRequest request = new NotificationCreateRequest(
+                        1L,
+                        NotificationType.PAYMENT_CONFIRMED,
+                        NotificationChannel.EMAIL,
+                        11_001L,
+                        "FACADE_IMMEDIATE",
+                        null
+                );
+
+        notificationFacade.register(request);
+
+        verify(taskScheduler, never()).schedule(any(Runnable.class), any(Instant.class));
+        verify(notificationEventListener, atLeastOnce()).handleNotificationCreated(any());
+    }
+
+    @Test
+    @DisplayName("recoverScheduledNotifications() — 아직 시각이 안 된 예약은 TaskScheduler에 재등록한다")
+    void reRegistersSchedule_whenScheduledTimeIsStillInFuture() {
+        LocalDateTime future = LocalDateTime.now().plusDays(1);
+        Notification n = Notification.builder()
+                .receiverId(1L)
+                .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                .channel(NotificationChannel.IN_APP)
+                .status(NotificationStatus.SCHEDULED)
+                .referenceId(11_002L)
+                .referenceType("RECOVER_FUTURE")
+                .idempotencyKey("recover-future-" + System.nanoTime())
+                .retryCount(0)
+                .maxRetryCount(3)
+                .scheduledAt(future)
+                .deleted(false)
+                .build();
+        Notification saved = notificationJpaRepository.save(n);
+
+        notificationFacade.recoverScheduledNotifications(LocalDateTime.now());
+
+        verify(taskScheduler, times(1)).schedule(any(Runnable.class), eq(future.atZone(ZoneId.systemDefault()).toInstant()));
+        Notification persisted = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+        assertThat(persisted.getStatus()).isEqualTo(NotificationStatus.SCHEDULED);
+    }
+
+    @Test
+    @DisplayName("recoverScheduledNotifications() — 이미 시각이 지난 예약은 즉시 PENDING 전환 및 이벤트 발행")
+    void movesToPending_whenScheduledTimeHasPassedOnRecover() {
+        LocalDateTime past = LocalDateTime.now().minusMinutes(30);
+        Notification n = Notification.builder()
+                .receiverId(1L)
+                .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                .channel(NotificationChannel.IN_APP)
+                .status(NotificationStatus.SCHEDULED)
+                .referenceId(11_003L)
+                .referenceType("RECOVER_PAST")
+                .idempotencyKey("recover-past-" + System.nanoTime())
+                .retryCount(0)
+                .maxRetryCount(3)
+                .scheduledAt(past)
+                .deleted(false)
+                .build();
+        Notification saved = notificationJpaRepository.save(n);
+
+        notificationFacade.recoverScheduledNotifications(LocalDateTime.now());
+
+        verify(notificationService, times(1)).scheduledToPending(saved.getId());
+        Notification persisted = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+        assertThat(persisted.getStatus()).isEqualTo(NotificationStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("sendScheduledNotifications() — 만기된 SCHEDULED 알림을 PENDING으로 전환한다")
+    void promotesDueScheduledToPending_whenSendScheduledNotifications() {
+        LocalDateTime past = LocalDateTime.now().minusMinutes(1);
+        Notification n = Notification.builder()
+                .receiverId(1L)
+                .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                .channel(NotificationChannel.IN_APP)
+                .status(NotificationStatus.SCHEDULED)
+                .referenceId(11_004L)
+                .referenceType("POLL_DUE")
+                .idempotencyKey("poll-due-" + System.nanoTime())
+                .retryCount(0)
+                .maxRetryCount(3)
+                .scheduledAt(past)
+                .deleted(false)
+                .build();
+        Notification saved = notificationJpaRepository.save(n);
+
+        notificationFacade.sendScheduledNotifications();
+
+        Notification persisted = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+        assertThat(persisted.getStatus()).isEqualTo(NotificationStatus.PENDING);
+        verify(notificationEventListener, atLeastOnce()).handleNotificationCreated(any());
     }
 
     @Test

--- a/src/test/java/com/becnotificationsystem/application/notification/NotificationServiceIntegrationTest.java
+++ b/src/test/java/com/becnotificationsystem/application/notification/NotificationServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -20,6 +21,7 @@ import com.becnotificationsystem.infrastructure.notification.InAppNotificationSe
 import com.becnotificationsystem.infrastructure.notification.NotificationJpaRepository;
 import com.becnotificationsystem.interfaces.api.notification.NotificationCreateRequest;
 import com.becnotificationsystem.interfaces.listener.NotificationEventListener;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -455,6 +457,269 @@ class NotificationServiceIntegrationTest {
                     notificationService.sendNotification(nonExistentId)
             );
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+    }
+
+    @DisplayName("예약 등록 및 예약 처리(scheduledToPending)를 할 때,")
+    @Nested
+    class ScheduledRegistration {
+
+        @DisplayName("scheduledAt이 미래이면 SCHEDULED 상태로 저장된다.")
+        @Test
+        void savesScheduledNotification_whenScheduledAtIsFuture() {
+            LocalDateTime future = LocalDateTime.now().plusHours(2);
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    1L,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.IN_APP,
+                    500L,
+                    "SCHEDULED_ORDER",
+                    future
+            );
+
+            NotificationInfo.Detail result = notificationService.register(request);
+
+            assertThat(result.status()).isEqualTo(NotificationStatus.SCHEDULED);
+            assertThat(result.scheduledAt()).isEqualTo(future);
+
+            Notification persisted = notificationJpaRepository.findById(result.notificationId()).orElseThrow();
+            assertThat(persisted.getStatus()).isEqualTo(NotificationStatus.SCHEDULED);
+        }
+
+        @DisplayName("scheduledToPending()은 SCHEDULED 알림을 PENDING으로 바꾸고 이벤트를 발행한다.")
+        @Test
+        void publishesEvent_whenScheduledNotificationBecomesPending() {
+            LocalDateTime future = LocalDateTime.now().plusHours(1);
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    1L,
+                    NotificationType.PAYMENT_CONFIRMED,
+                    NotificationChannel.IN_APP,
+                    600L,
+                    "SCHEDULED_PAYMENT",
+                    future
+            );
+            NotificationInfo.Detail saved = notificationService.register(request);
+
+            notificationService.scheduledToPending(saved.notificationId());
+
+            Notification persisted = notificationJpaRepository.findById(saved.notificationId()).orElseThrow();
+            assertThat(persisted.getStatus()).isEqualTo(NotificationStatus.PENDING);
+            verify(notificationEventListener, times(1)).handleNotificationCreated(any());
+        }
+
+        @DisplayName("scheduledToPending()은 SCHEDULED가 아닌 알림에 대해 상태를 바꾸지 않고 이벤트도 발행하지 않는다.")
+        @Test
+        void doesNothing_whenNotificationIsNotScheduled() {
+            Notification pending = savePendingNotification(NotificationChannel.IN_APP);
+
+            notificationService.scheduledToPending(pending.getId());
+
+            Notification persisted = notificationJpaRepository.findById(pending.getId()).orElseThrow();
+            assertThat(persisted.getStatus()).isEqualTo(NotificationStatus.PENDING);
+            verify(notificationEventListener, never()).handleNotificationCreated(any());
+        }
+
+        @DisplayName("findAllScheduled()은 SCHEDULED 상태 알림만 반환한다.")
+        @Test
+        void returnsOnlyScheduledNotifications() {
+            notificationService.register(new NotificationCreateRequest(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    700L, "MULTI_SCHED", LocalDateTime.now().plusDays(1)));
+            savePendingNotification(NotificationChannel.IN_APP);
+
+            var scheduled = notificationService.findAllScheduled();
+
+            assertThat(scheduled).hasSize(1);
+            assertThat(scheduled.get(0).status()).isEqualTo(NotificationStatus.SCHEDULED);
+        }
+
+        @DisplayName("findDueScheduledIds()는 scheduledAt이 기준 시각 이하인 SCHEDULED 알림 ID만 반환한다.")
+        @Test
+        void returnsDueScheduledIds_onlyWhenScheduledAtHasPassed() {
+            Notification due = Notification.builder()
+                    .receiverId(1L)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.IN_APP)
+                    .status(NotificationStatus.SCHEDULED)
+                    .referenceId(800L)
+                    .referenceType("DUE")
+                    .idempotencyKey("due-scheduled-1")
+                    .retryCount(0)
+                    .maxRetryCount(3)
+                    .scheduledAt(LocalDateTime.now().minusMinutes(5))
+                    .deleted(false)
+                    .build();
+            notificationJpaRepository.save(due);
+            Notification future = Notification.builder()
+                    .receiverId(1L)
+                    .notificationType(NotificationType.PAYMENT_CONFIRMED)
+                    .channel(NotificationChannel.IN_APP)
+                    .status(NotificationStatus.SCHEDULED)
+                    .referenceId(801L)
+                    .referenceType("FUTURE")
+                    .idempotencyKey("future-scheduled-1")
+                    .retryCount(0)
+                    .maxRetryCount(3)
+                    .scheduledAt(LocalDateTime.now().plusDays(1))
+                    .deleted(false)
+                    .build();
+            notificationJpaRepository.save(future);
+
+            var ids = notificationService.findDueScheduledIds();
+
+            assertThat(ids).containsExactly(due.getId());
+        }
+    }
+
+    @DisplayName("읽음 처리(markAsRead)를 할 때,")
+    @Nested
+    class MarkAsRead {
+
+        private Notification saveInAppSent(Long receiverId) {
+            long suffix = System.nanoTime();
+            Notification n = Notification.of(
+                    receiverId,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.IN_APP,
+                    900L + (suffix % 10_000),
+                    "READ_TEST",
+                    "read-test-" + receiverId + "-" + suffix,
+                    null
+            );
+            Notification saved = notificationJpaRepository.save(n);
+            notificationService.sendNotification(saved.getId());
+            return notificationJpaRepository.findById(saved.getId()).orElseThrow();
+        }
+
+        @DisplayName("IN_APP + SENT이고 수신자 본인이면 READ로 전이되고 readAt이 반환된다.")
+        @Test
+        void marksAsRead_whenInAppSentAndReceiverMatches() {
+            Notification saved = saveInAppSent(1L);
+            LocalDateTime readAt = LocalDateTime.now();
+
+            NotificationInfo.ReadResult result = notificationService.markAsRead(saved.getId(), 1L, readAt);
+
+            assertThat(result.status()).isEqualTo(NotificationStatus.READ);
+            assertThat(result.readAt()).isNotNull();
+
+            Notification persisted = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertThat(persisted.getStatus()).isEqualTo(NotificationStatus.READ);
+            assertThat(persisted.getReadAt()).isNotNull();
+        }
+
+        @DisplayName("이미 READ인 알림에 대해 멱등적으로 호출하면 READ 상태와 readAt을 그대로 반환한다.")
+        @Test
+        void isIdempotent_whenAlreadyRead() {
+            Notification saved = saveInAppSent(1L);
+            LocalDateTime firstReadAt = LocalDateTime.now().minusMinutes(10);
+            notificationService.markAsRead(saved.getId(), 1L, firstReadAt);
+
+            NotificationInfo.ReadResult second = notificationService.markAsRead(saved.getId(), 1L, LocalDateTime.now());
+
+            assertThat(second.status()).isEqualTo(NotificationStatus.READ);
+            Notification persisted = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertThat(persisted.getReadAt()).isEqualTo(firstReadAt);
+        }
+
+        @DisplayName("EMAIL 채널이면 NOTIFICATION_CHANNEL_NOT_SUPPORTED 예외가 발생한다.")
+        @Test
+        void throwsException_whenChannelIsEmail() {
+            long suffix = System.nanoTime();
+            Notification pending = Notification.of(
+                    1L,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.EMAIL,
+                    901L + (suffix % 10_000),
+                    "EMAIL_READ",
+                    "email-read-" + suffix,
+                    null
+            );
+            Notification saved = notificationJpaRepository.save(pending);
+            notificationService.sendNotification(saved.getId());
+
+            BusinessException ex = assertThrows(BusinessException.class, () ->
+                    notificationService.markAsRead(saved.getId(), 1L, LocalDateTime.now()));
+
+            assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_CHANNEL_NOT_SUPPORTED);
+        }
+
+        @DisplayName("수신자가 아니면 NOTIFICATION_ACCESS_DENIED 예외가 발생한다.")
+        @Test
+        void throwsException_whenReceiverDoesNotMatch() {
+            Notification saved = saveInAppSent(1L);
+
+            BusinessException ex = assertThrows(BusinessException.class, () ->
+                    notificationService.markAsRead(saved.getId(), 2L, LocalDateTime.now()));
+
+            assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_ACCESS_DENIED);
+        }
+
+        @DisplayName("SENT가 아닌 알림은 compareAndSwap이 적용되지 않아 상태가 그대로이고 예외 없이 결과를 반환한다.")
+        @Test
+        void returnsCurrentState_whenNotSent() {
+            Notification pending = savePendingNotification(NotificationChannel.IN_APP);
+
+            NotificationInfo.ReadResult result = notificationService.markAsRead(pending.getId(), 1L, LocalDateTime.now());
+
+            assertThat(result.status()).isEqualTo(NotificationStatus.PENDING);
+            assertThat(result.readAt()).isNull();
+        }
+    }
+
+    @DisplayName("수동 재시도(manualRetry)를 할 때,")
+    @Nested
+    class ManualRetry {
+
+        private Notification saveDeadLetter(Long receiverId) {
+            long suffix = System.nanoTime();
+            Notification n = Notification.builder()
+                    .receiverId(receiverId)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.DEAD_LETTER)
+                    .referenceId(1000L + (suffix % 10_000))
+                    .referenceType("DL")
+                    .idempotencyKey("dl-" + receiverId + "-" + suffix)
+                    .retryCount(3)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build();
+            return notificationJpaRepository.save(n);
+        }
+
+        @DisplayName("DEAD_LETTER이고 수신자 본인이면 PENDING으로 복구하고 이벤트를 발행한다.")
+        @Test
+        void resetsToPending_whenDeadLetterAndReceiverMatches() {
+            Notification saved = saveDeadLetter(1L);
+
+            NotificationInfo.Detail result = notificationService.manualRetry(saved.getId(), 1L);
+
+            assertThat(result.status()).isEqualTo(NotificationStatus.PENDING);
+            Notification persisted = notificationJpaRepository.findById(saved.getId()).orElseThrow();
+            assertThat(persisted.getRetryCount()).isEqualTo(3);
+            verify(notificationEventListener, times(1)).handleNotificationCreated(any());
+        }
+
+        @DisplayName("DEAD_LETTER가 아니면 NOTIFICATION_RETRY_NOT_ALLOWED 예외가 발생한다.")
+        @Test
+        void throwsException_whenStatusIsNotDeadLetter() {
+            Notification pending = savePendingNotification(NotificationChannel.IN_APP);
+
+            BusinessException ex = assertThrows(BusinessException.class, () ->
+                    notificationService.manualRetry(pending.getId(), 1L));
+
+            assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_RETRY_NOT_ALLOWED);
+        }
+
+        @DisplayName("수신자가 아니면 NOTIFICATION_ACCESS_DENIED 예외가 발생한다.")
+        @Test
+        void throwsException_whenReceiverDoesNotMatch() {
+            Notification saved = saveDeadLetter(1L);
+
+            BusinessException ex = assertThrows(BusinessException.class, () ->
+                    notificationService.manualRetry(saved.getId(), 2L));
+
+            assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.NOTIFICATION_ACCESS_DENIED);
         }
     }
 }

--- a/src/test/java/com/becnotificationsystem/domain/notification/NotificationTest.java
+++ b/src/test/java/com/becnotificationsystem/domain/notification/NotificationTest.java
@@ -57,6 +57,44 @@ class NotificationTest {
             assertThat(notification.getScheduledAt()).isNull();
             assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING);
         }
+
+        @DisplayName("scheduledAt이 현재 시각보다 미래이면 SCHEDULED 상태로 생성된다.")
+        @Test
+        void createsScheduledNotification_whenScheduledAtIsInFuture() {
+            // arrange
+            LocalDateTime future = LocalDateTime.now().plusDays(1);
+
+            // act
+            Notification notification = Notification.of(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    100L, "ORDER", "scheduled-key", future
+            );
+
+            // assert
+            assertAll(
+                    () -> assertThat(notification.getStatus()).isEqualTo(NotificationStatus.SCHEDULED),
+                    () -> assertThat(notification.getScheduledAt()).isEqualTo(future)
+            );
+        }
+
+        @DisplayName("scheduledAt이 현재 시각 이전이면 PENDING 상태로 생성된다.")
+        @Test
+        void createsPendingNotification_whenScheduledAtIsInPast() {
+            // arrange
+            LocalDateTime past = LocalDateTime.now().minusMinutes(1);
+
+            // act
+            Notification notification = Notification.of(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    100L, "ORDER", "past-schedule-key", past
+            );
+
+            // assert
+            assertAll(
+                    () -> assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING),
+                    () -> assertThat(notification.getScheduledAt()).isEqualTo(past)
+            );
+        }
     }
 
     @DisplayName("멱등성 키를 생성할 때,")
@@ -279,6 +317,147 @@ class NotificationTest {
 
             // assert
             assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING);
+        }
+
+        @DisplayName("markAsPending()을 호출하면 SCHEDULED에서 PENDING으로 전이된다.")
+        @Test
+        void transitionsToPending_whenMarkAsPendingCalledFromScheduled() {
+            // arrange
+            LocalDateTime future = LocalDateTime.now().plusHours(1);
+            Notification notification = Notification.of(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    100L, "ORDER", "sched-to-pending", future
+            );
+
+            // act
+            notification.markAsPending();
+
+            // assert
+            assertThat(notification.getStatus()).isEqualTo(NotificationStatus.PENDING);
+        }
+
+        @DisplayName("markAsRead()을 호출하면 READ 상태가 되고 readAt이 설정된다.")
+        @Test
+        void transitionsToRead_whenMarkAsReadCalled() {
+            // arrange
+            Notification notification = createPendingNotification();
+            notification.startProcessing();
+            notification.markAsSent();
+            LocalDateTime readAt = LocalDateTime.now().plusSeconds(1);
+
+            // act
+            notification.markAsRead(readAt);
+
+            // assert
+            assertAll(
+                    () -> assertThat(notification.getStatus()).isEqualTo(NotificationStatus.READ),
+                    () -> assertThat(notification.getReadAt()).isEqualTo(readAt)
+            );
+        }
+    }
+
+    @DisplayName("matchesReceiver()를 호출할 때,")
+    @Nested
+    class MatchesReceiver {
+
+        @DisplayName("동일한 receiverId이면 true를 반환한다.")
+        @Test
+        void returnsTrue_whenReceiverIdMatches() {
+            // arrange
+            Notification notification = Notification.of(
+                    42L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    1L, "ORDER", "match-key", null
+            );
+
+            // act & assert
+            assertThat(notification.matchesReceiver(42L)).isTrue();
+        }
+
+        @DisplayName("다른 receiverId이면 false를 반환한다.")
+        @Test
+        void returnsFalse_whenReceiverIdDiffers() {
+            // arrange
+            Notification notification = Notification.of(
+                    42L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    1L, "ORDER", "mismatch-key", null
+            );
+
+            // act & assert
+            assertThat(notification.matchesReceiver(99L)).isFalse();
+        }
+
+        @DisplayName("null을 넘기면 false를 반환한다.")
+        @Test
+        void returnsFalse_whenReceiverIdIsNull() {
+            // arrange
+            Notification notification = Notification.of(
+                    42L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    1L, "ORDER", "null-receiver-key", null
+            );
+
+            // act & assert
+            assertThat(notification.matchesReceiver(null)).isFalse();
+        }
+    }
+
+    @DisplayName("isProcessable()을 호출할 때,")
+    @Nested
+    class IsProcessable {
+
+        @DisplayName("PENDING이면 true를 반환한다.")
+        @Test
+        void returnsTrue_whenPending() {
+            Notification n = Notification.of(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.EMAIL,
+                    1L, "ORDER", "proc-pending", null
+            );
+            assertThat(n.isProcessable()).isTrue();
+        }
+
+        @DisplayName("FAILED이면 true를 반환한다.")
+        @Test
+        void returnsTrue_whenFailed() {
+            Notification n = Notification.builder()
+                    .receiverId(1L)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.FAILED)
+                    .referenceId(1L)
+                    .referenceType("ORDER")
+                    .idempotencyKey("proc-failed")
+                    .retryCount(1)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build();
+            assertThat(n.isProcessable()).isTrue();
+        }
+
+        @DisplayName("SCHEDULED이면 false를 반환한다.")
+        @Test
+        void returnsFalse_whenScheduled() {
+            Notification n = Notification.of(
+                    1L, NotificationType.ENROLLMENT_COMPLETE, NotificationChannel.IN_APP,
+                    1L, "ORDER", "proc-scheduled", LocalDateTime.now().plusHours(1)
+            );
+            assertThat(n.isProcessable()).isFalse();
+        }
+
+        @DisplayName("SENT이면 false를 반환한다.")
+        @Test
+        void returnsFalse_whenSent() {
+            Notification n = Notification.builder()
+                    .receiverId(1L)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.IN_APP)
+                    .status(NotificationStatus.SENT)
+                    .referenceId(1L)
+                    .referenceType("ORDER")
+                    .idempotencyKey("proc-sent")
+                    .retryCount(0)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build();
+            assertThat(n.isProcessable()).isFalse();
         }
     }
 }

--- a/src/test/java/com/becnotificationsystem/interfaces/api/notification/NotificationControllerE2ETest.java
+++ b/src/test/java/com/becnotificationsystem/interfaces/api/notification/NotificationControllerE2ETest.java
@@ -2,6 +2,10 @@ package com.becnotificationsystem.interfaces.api.notification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.becnotificationsystem.application.notification.NotificationInfo;
 import com.becnotificationsystem.application.notification.NotificationRepository;
@@ -13,11 +17,15 @@ import com.becnotificationsystem.global.common.response.CommonApiResponse;
 import com.becnotificationsystem.global.common.response.PageResponse;
 import com.becnotificationsystem.support.IntegrationTest;
 import com.becnotificationsystem.utils.DatabaseCleanUp;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
@@ -25,9 +33,14 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
 class NotificationControllerE2ETest extends IntegrationTest {
 
     private static final String ENDPOINT = "/api/v1/notifications";
@@ -36,14 +49,42 @@ class NotificationControllerE2ETest extends IntegrationTest {
     private TestRestTemplate testRestTemplate;
 
     @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
     private NotificationRepository notificationRepository;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
     @AfterEach
     void tearDown() {
         databaseCleanUp.truncateAllTables();
+    }
+
+    private Long persistInAppSent(long receiverId, long referenceId, String idempotencyKey) {
+        Notification saved = notificationRepository.save(Notification.of(
+                receiverId,
+                NotificationType.ENROLLMENT_COMPLETE,
+                NotificationChannel.IN_APP,
+                referenceId,
+                "E2E_READ",
+                idempotencyKey,
+                null
+        ));
+        jdbcTemplate.update(
+                "UPDATE notification SET status = ?, sent_at = ? WHERE id = ?",
+                NotificationStatus.SENT.name(),
+                LocalDateTime.now(),
+                saved.getId()
+        );
+        return saved.getId();
     }
 
     @DisplayName("POST /api/v1/notifications - 알림 등록")
@@ -206,6 +247,200 @@ class NotificationControllerE2ETest extends IntegrationTest {
 
             // assert
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @DisplayName("POST /api/v1/notifications — 예약 발송 검증 (MockMvc)")
+    @Nested
+    class RegisterSchedule {
+
+        @DisplayName("scheduledAt이 미래이면 202이고 응답 status는 SCHEDULED이다.")
+        @Test
+        void returns202WithScheduledStatus_whenScheduledAtIsFuture() throws Exception {
+            NotificationCreateRequest body = new NotificationCreateRequest(
+                    1L,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.IN_APP,
+                    20_001L,
+                    "E2E_SCHEDULE",
+                    LocalDateTime.now().plusHours(2)
+            );
+
+            mockMvc.perform(post(ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isAccepted())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.status").value("SCHEDULED"));
+        }
+
+        @DisplayName("scheduledAt이 현재 이전이면 400과 검증 메시지를 반환한다.")
+        @Test
+        void returns400_whenScheduledAtIsNotFuture() throws Exception {
+            NotificationCreateRequest body = new NotificationCreateRequest(
+                    1L,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.IN_APP,
+                    20_002L,
+                    "E2E_PAST_SCHEDULE",
+                    LocalDateTime.now().minusMinutes(1)
+            );
+
+            mockMvc.perform(post(ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(body)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+        }
+    }
+
+    @DisplayName("PATCH /api/v1/notifications/{id}/read (MockMvc)")
+    @Nested
+    class MarkAsRead {
+
+        @DisplayName("IN_APP SENT이고 X-User-Id가 수신자와 일치하면 200과 READ를 반환한다.")
+        @Test
+        void returns200_whenInAppSentAndReceiverMatches() throws Exception {
+            Long id = persistInAppSent(10L, 30_001L, "read-e2e-1");
+
+            mockMvc.perform(patch(ENDPOINT + "/" + id + "/read")
+                            .header("X-User-Id", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.status").value("READ"))
+                    .andExpect(jsonPath("$.data.readAt").exists());
+        }
+
+        @DisplayName("이미 READ인 경우에도 200으로 멱등 응답한다.")
+        @Test
+        void returns200_whenAlreadyRead() throws Exception {
+            Long id = persistInAppSent(10L, 30_002L, "read-e2e-idem");
+            LocalDateTime existingReadAt = LocalDateTime.now().minusDays(1);
+            jdbcTemplate.update(
+                    "UPDATE notification SET status = ?, read_at = ? WHERE id = ?",
+                    NotificationStatus.READ.name(),
+                    existingReadAt,
+                    id
+            );
+
+            mockMvc.perform(patch(ENDPOINT + "/" + id + "/read")
+                            .header("X-User-Id", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.status").value("READ"));
+
+            mockMvc.perform(patch(ENDPOINT + "/" + id + "/read")
+                            .header("X-User-Id", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.status").value("READ"));
+        }
+
+        @DisplayName("EMAIL 채널이면 400 NOTIFICATION_CHANNEL_NOT_SUPPORTED이다.")
+        @Test
+        void returns400_whenChannelIsEmail() throws Exception {
+            Notification saved = notificationRepository.save(Notification.of(
+                    10L,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.EMAIL,
+                    30_003L,
+                    "READ_EMAIL",
+                    "read-e2e-email",
+                    null
+            ));
+            jdbcTemplate.update(
+                    "UPDATE notification SET status = ?, sent_at = ? WHERE id = ?",
+                    NotificationStatus.SENT.name(),
+                    LocalDateTime.now(),
+                    saved.getId()
+            );
+
+            mockMvc.perform(patch(ENDPOINT + "/" + saved.getId() + "/read")
+                            .header("X-User-Id", "10"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("NOTIFICATION_CHANNEL_NOT_SUPPORTED"));
+        }
+
+        @DisplayName("수신자가 아니면 403 NOTIFICATION_ACCESS_DENIED이다.")
+        @Test
+        void returns403_whenUserIsNotReceiverForRead() throws Exception {
+            Long id = persistInAppSent(10L, 30_004L, "read-e2e-403");
+
+            mockMvc.perform(patch(ENDPOINT + "/" + id + "/read")
+                            .header("X-User-Id", "99"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOTIFICATION_ACCESS_DENIED"));
+        }
+    }
+
+    @DisplayName("POST /api/v1/notifications/{id}/retry (MockMvc)")
+    @Nested
+    class ManualRetry {
+
+        @DisplayName("DEAD_LETTER이고 수신자 본인이면 200과 PENDING을 반환한다.")
+        @Test
+        void returns200_whenDeadLetterAndReceiverMatches() throws Exception {
+            Notification saved = notificationRepository.save(Notification.builder()
+                    .receiverId(10L)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.DEAD_LETTER)
+                    .referenceId(40_001L)
+                    .referenceType("RETRY_E2E")
+                    .idempotencyKey("retry-e2e-1")
+                    .retryCount(3)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build());
+
+            MvcResult result = mockMvc.perform(post(ENDPOINT + "/" + saved.getId() + "/retry")
+                            .header("X-User-Id", "10"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.status").value("PENDING"))
+                    .andReturn();
+
+            JsonNode root = objectMapper.readTree(result.getResponse().getContentAsString());
+            assertThat(root.get("data").get("retryCount").asInt()).isEqualTo(3);
+        }
+
+        @DisplayName("DEAD_LETTER가 아니면 400 NOTIFICATION_RETRY_NOT_ALLOWED이다.")
+        @Test
+        void returns400_whenNotDeadLetter() throws Exception {
+            Notification saved = notificationRepository.save(Notification.of(
+                    10L,
+                    NotificationType.ENROLLMENT_COMPLETE,
+                    NotificationChannel.IN_APP,
+                    40_002L,
+                    "RETRY_PENDING",
+                    "retry-e2e-pending",
+                    null
+            ));
+
+            mockMvc.perform(post(ENDPOINT + "/" + saved.getId() + "/retry")
+                            .header("X-User-Id", "10"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("NOTIFICATION_RETRY_NOT_ALLOWED"));
+        }
+
+        @DisplayName("수신자가 아니면 403 NOTIFICATION_ACCESS_DENIED이다.")
+        @Test
+        void returns403_whenUserIsNotReceiverForRetry() throws Exception {
+            Notification saved = notificationRepository.save(Notification.builder()
+                    .receiverId(10L)
+                    .notificationType(NotificationType.ENROLLMENT_COMPLETE)
+                    .channel(NotificationChannel.EMAIL)
+                    .status(NotificationStatus.DEAD_LETTER)
+                    .referenceId(40_003L)
+                    .referenceType("RETRY_FORBIDDEN")
+                    .idempotencyKey("retry-e2e-403")
+                    .retryCount(3)
+                    .maxRetryCount(3)
+                    .deleted(false)
+                    .build());
+
+            mockMvc.perform(post(ENDPOINT + "/" + saved.getId() + "/retry")
+                            .header("X-User-Id", "99"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.code").value("NOTIFICATION_ACCESS_DENIED"));
         }
     }
 }

--- a/src/test/java/com/becnotificationsystem/interfaces/listener/NotificationEventListenerIntegrationTest.java
+++ b/src/test/java/com/becnotificationsystem/interfaces/listener/NotificationEventListenerIntegrationTest.java
@@ -2,8 +2,8 @@ package com.becnotificationsystem.interfaces.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.becnotificationsystem.application.notification.NotificationFacade;
 import com.becnotificationsystem.application.notification.NotificationInfo;
-import com.becnotificationsystem.application.notification.NotificationService;
 import com.becnotificationsystem.domain.notification.NotificationChannel;
 import com.becnotificationsystem.domain.notification.NotificationStatus;
 import com.becnotificationsystem.domain.notification.NotificationType;
@@ -22,7 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 class NotificationEventListenerIntegrationTest {
 
     @Autowired
-    private NotificationService notificationService;
+    private NotificationFacade notificationFacade;
 
     @Autowired
     private NotificationJpaRepository notificationJpaRepository;
@@ -46,7 +46,7 @@ class NotificationEventListenerIntegrationTest {
             );
 
             // act
-            NotificationInfo.Detail result = notificationService.register(request);
+            NotificationInfo.Detail result = notificationFacade.register(request);
 
             // assert — 비동기 발송 처리 완료 대기 (최대 3초, 100ms 간격 폴링)
             NotificationStatus status = NotificationStatus.PENDING;


### PR DESCRIPTION
## 📝 작업 내용
1. 예약 발송 스케줄링 추가
    - `NotificationStatus.SCHEDULED` 상태 추가 - 즉시 발송 대기(PENDING)와 예약 대기를 분리
    - `NotificationStartupScheduler` 추가 - 서버 재시작 시 DB에서 `SCHEDULED` 알림을 조회해 동적 스케줄러 재등록
    - `NotificationScheduledSendScheduler` 추가 - 10분 주기 폴링으로 동적 스케줄러 누락 케이스 확인 
    - `NotificationCreateRequest.scheduledAt` - `null`이면 즉시 발송(기존 동작), 값이 있다면 유효성 검증 후 예약 발송 

2. 읽음 처리 API 추가 (`PATCH /api/v1/notifications/{notificationId}/read`)
    - 기존 `compareAndSwap(SENT → READ)`을 활용한 조건부 UPDATE로 DB 레벨 원자성 보장 
    - 여러 기기에서 동시 요청해도 하나만 처리되고 나머지는 현재 상태 그대로 200 반환 (멱등성)
    - EMAIL 채널 요청 시 400, 수신자 본인이 아닌 경우 403 

3. 수동 재시도 API 추가 (`POST /api/v1/notifications/{notificationId}/retry`)
    - `DEAD_LETTER` 상태인 알림만 재시도 가능, 그 외 상태는 400 
    - `retry_count` 유지 — 수동 재시도는 카운터 리셋이 아닌 1회 추가 기회    
    - 수신자 본인이 아닌 경우 403

4. 테스트 코드 작성 
    - `NotificationTest`: Notification SCHEDULED 상태 관련 단위 테스트
    - `NotificationServiceIntegrationTest`, `NotificationFacadeIntegrationTest`: 예약 발송, 읽음 처리, 수동 재시도 관련 통합 테스트
    - `NotificationControllerE2ETest`:  예약 발송, 읽음 처리, 수동 재시도 관련 E2E 테스트 

## 🔗 관련 이슈
#8 
